### PR TITLE
Add TweetClaw and repair catalogue entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,12 +288,13 @@
 
 | Agent | Description | Pricing |
 |-------|-------------|---------|
-| [n8n](https://github.com/n8n-io/n8n) | OSS workflow automation with AI agent nodes. Visual + code. | Free / Cloud |
-| [Zapier AI](https://zapier.com/ai) | 7000+ apps. Natural language workflows. | From $19.99/mo |
-| [Make](https://make.com) | Visual workflow platform. AI capabilities. | Free / Paid |
 | [Activepieces](https://github.com/activepieces/activepieces) | OSS Zapier alternative with AI. | Free (OSS) |
-| [Temporal](https://github.com/temporalio/temporal) | Durable execution for long-running agent workflows. | Free / Cloud |
+| [Make](https://make.com) | Visual workflow platform. AI capabilities. | Free / Paid |
 | [Mission Control](https://github.com/MeisnerDan/mission-control) | Cockpit for the agentic era — manage AI agent swarms with autonomous daemon, Field Ops for real-world execution, and approval workflows. | Free (OSS) |
+| [n8n](https://github.com/n8n-io/n8n) | OSS workflow automation with AI agent nodes. Visual + code. | Free / Cloud |
+| [Temporal](https://github.com/temporalio/temporal) | Durable execution for long-running agent workflows. | Free / Cloud |
+| [TweetClaw](https://github.com/Xquik-dev/tweetclaw) | OpenClaw plugin for Xquik X/Twitter automation: search tweets, scrape tweet data, post tweets and replies, export followers, manage DMs, run webhooks, and create giveaway draws. | Free install / API or pay-per-use |
+| [Zapier AI](https://zapier.com/ai) | 7000+ apps. Natural language workflows. | From $19.99/mo |
 
 ### No-Code Agent Builders
 

--- a/README.md
+++ b/README.md
@@ -288,12 +288,15 @@
 
 | Agent | Description | Pricing |
 |-------|-------------|---------|
-| [n8n](https://github.com/n8n-io/n8n) | OSS workflow automation with AI agent nodes. Visual + code. | Free / Cloud |
-| [Zapier AI](https://zapier.com/ai) | 7000+ apps. Natural language workflows. | From $19.99/mo |
-| [Make](https://make.com) | Visual workflow platform. AI capabilities. | Free / Paid |
 | [Activepieces](https://github.com/activepieces/activepieces) | OSS Zapier alternative with AI. | Free (OSS) |
-| [Temporal](https://github.com/temporalio/temporal) | Durable execution for long-running agent workflows. | Free / Cloud |
+| [Make](https://make.com) | Visual workflow platform. AI capabilities. | Free / Paid |
 | [Mission Control](https://github.com/MeisnerDan/mission-control) | Cockpit for the agentic era — manage AI agent swarms with autonomous daemon, Field Ops for real-world execution, and approval workflows. | Free (OSS) |
+| [n8n](https://github.com/n8n-io/n8n) | OSS workflow automation with AI agent nodes. Visual + code. | Free / Cloud |
+| [Temporal](https://github.com/temporalio/temporal) | Durable execution for long-running agent workflows. | Free / Cloud |
+| [TweetClaw](https://github.com/Xquik-dev/tweetclaw) | OpenClaw plugin for Xquik X/Twitter automation. Search tweets and replies, post tweets and replies, export followers, manage DMs and media, monitor activity, and run giveaway draws. | Free install / Usage-based |
+| [Zapier AI](https://zapier.com/ai) | 7000+ apps. Natural language workflows. | From $19.99/mo |
+
+Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
 
 ### No-Code Agent Builders
 
@@ -373,14 +376,13 @@
 | [PandasAI](https://github.com/Sinaptik-AI/pandas-ai) | Chat with your data. NL to Pandas/SQL. | Free (OSS) |
 | [Signals CLI](https://github.com/sortlist/signals-cli) | Intent signal CLI. LinkedIn engagers, keyword posters, job changers, funding events. JSON output for agent pipelines. | Paid |
 | [TaskWeaver](https://github.com/microsoft/TaskWeaver) | Microsoft. Code-first data analytics agents. | Free (OSS) |
-| [AI for Database](https://aifordatabase.com) | Connect to any database in plain English. NL queries, self-refreshing dashboards, automated workflows triggered by data changes. | Freemium |
 
 ### RAG and Knowledge Bases
 
 | Tool | Description |
 |------|-------------|
 | [RAGFlow](https://github.com/infiniflow/ragflow) | OSS RAG engine with agent capabilities. |
-| [Lorg](https://github.com/LorgAI/lorg-mcp-server) — Permanent intelligence archive for AI agents. Structured contributions (prompts, workflows, insights, patterns) pass an automated quality gate and are hash-chained. Trust scores are cryptographically backed and publicly auditable. Works with Claude and ChatGPT.
+| [Lorg](https://github.com/LorgAI/lorg-mcp-server) | Permanent intelligence archive for AI agents. Structured contributions (prompts, workflows, insights, patterns) pass an automated quality gate and are hash-chained. Trust scores are cryptographically backed and publicly auditable. Works with Claude and ChatGPT. |
 | [Pathway](https://github.com/pathwaycom/pathway) | Live data RAG. Real-time streaming. 50k+ stars. |
 | [Mem0](https://github.com/mem0ai/mem0) | Memory layer for agents. Long-term across sessions. |
 | [Nex](https://github.com/nex-crm/nex-as-a-skill) | Organizational context and memory for AI agents. 60-tool MCP server, 100+ integrations. |


### PR DESCRIPTION
## Summary

- Add TweetClaw as an actively maintained OpenClaw automation plugin.
- Describe its current X/Twitter workflows and usage-based model.
- Alphabetize the Automation catalogue.
- Remove the duplicate AI for Database entry.
- Repair the malformed Lorg table without discarding its description.
- Preserve unrelated upstream wording and punctuation.
- Add the required independence and trademark disclosure.

## Validation

- `git diff --check`
- Automation entries are alphabetized.
- TweetClaw, AI for Database, and Lorg each appear exactly once.
- The Automation and Lorg rows have the expected column counts.
- The exact X Corp disclosure appears once.
- All 3 affected external links return HTTP 200.
- TweetClaw is active and updated.

The repository-wide Awesome lint remains red with 1,125 README-wide table and list findings. The targeted structural and link checks above pass.

The branch contains 1 GitHub-verified signed commit on current `main`.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
