### PR TITLE
Add x402 protocol and agent-wallet-sdk to Protocols and Standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,8 @@
 | [OpenAI Function Calling](https://platform.openai.com/docs/guides/function-calling) | OpenAI native tool-use. JSON schema. |
 | [Tool Use (Anthropic)](https://docs.anthropic.com/en/docs/build-with-claude/tool-use) | Claude native tool-use. Structured JSON. |
 | [OpenAPI](https://github.com/OAI/OpenAPI-Specification) | Industry-standard API spec. Foundation for agent tools. |
+| [x402](https://github.com/coinbase/x402) | Coinbase open standard for HTTP-native payments. Enables agents to pay for APIs autonomously. |
+| [agent-wallet-sdk](https://www.npmjs.com/package/agentwallet-sdk) | Non-custodial multi-chain wallet SDK for AI agents. x402 payments, CCTP transfers, CowSwap swaps. |
 
 ---
 


### PR DESCRIPTION
Adds two entries to the Protocols and Standards section:

1. **[x402](https://github.com/coinbase/x402)** — Coinbase's open standard for HTTP-native payments, enabling AI agents to pay for API access autonomously using the HTTP 402 status code.

2. **[agent-wallet-sdk](https://www.npmjs.com/package/agentwallet-sdk)** — Non-custodial multi-chain wallet SDK purpose-built for AI agents. Supports x402 payments, CCTP cross-chain USDC transfers, and CowSwap solver integration.

Both are directly relevant to the agent ecosystem — x402 is becoming the standard for agent-to-service payments, and agent-wallet-sdk is one of the few SDKs providing wallet infrastructure specifically for autonomous agents.