### PR TITLE
Add iGPT to RAG and Knowledge Bases

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@
 | [Qdrant](https://github.com/qdrant/qdrant) | High-performance vector DB in Rust. |
 | [Milvus](https://github.com/milvus-io/milvus) | Cloud-native vector DB. Billion-scale. |
 | [Pinecone](https://pinecone.io) | Managed vector DB. Serverless. Low-latency. |
+| [iGPT](https://igpt.ai) | Email Intelligence API. Converts email threads into reasoning-ready JSON for agents. |
 
 ---
 


### PR DESCRIPTION
## Added iGPT to RAG and Knowledge Bases

Added [iGPT](https://www.igpt.ai) to the **RAG and Knowledge Bases** section under Data and Research Agents.

iGPT is an Email Intelligence API that gives AI agents structured, reasoning-ready context from email and communication data. Returns JSON with decisions, commitments, participants, and source citations.

### Details

- **SDKs:** Python ([PyPI](https://pypi.org/project/igptai/)) and Node.js ([npm](https://www.npmjs.com/package/igptai))
- **Integrations:** LangChain, LlamaIndex, MCP
- **Website:** [igpt.ai](https://igpt.ai)
- **Docs:** [docs.igpt.ai](https://docs.igpt.ai)