### PR TITLE
Add Arch Tools — 61 AI tools with x402 USDC payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@
 | [Meta AI](https://meta.ai) | Llama-powered. WhatsApp/Messenger. Manus acquisition. | Free |
 | [Microsoft Copilot](https://copilot.microsoft.com) | Office 365 integration. Enterprise. | Free / $30/user |
 | [Coze](https://coze.com) | ByteDance agent builder. Visual workflow. Plugin marketplace. | Free / Paid |
+| [Arch Tools](https://archtools.dev) | 61 AI tools via REST API and MCP. Code analysis, scraping, image gen, NLP, crypto. x402 USDC payments on Base/Polygon/Avalanche/Solana. | Pay-per-call |
 
 ---
 


### PR DESCRIPTION
Adds [Arch Tools](https://archtools.dev) to the Multi-Agent Platforms section.

**Arch Tools** provides 61 production-ready AI tools (code analysis, web scraping, image generation, NLP, crypto, search, and more) accessible via REST API and MCP protocol. Native x402 USDC micropayments on Base, Polygon, Avalanche, and Solana. Built for AI agents.

- **GitHub:** https://github.com/Deesmo/Arch-AI-Tools
- **MCP endpoint:** https://arch-tools-mcp.onrender.com/mcp
- **x402scan:** https://x402scan.com/resource/archtools.dev