### PR TITLE
Add ATXP to Protocols and Standards — agent wallet, email, and paid tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@
 | [OpenAI Function Calling](https://platform.openai.com/docs/guides/function-calling) | OpenAI native tool-use. JSON schema. |
 | [Tool Use (Anthropic)](https://docs.anthropic.com/en/docs/build-with-claude/tool-use) | Claude native tool-use. Structured JSON. |
 | [OpenAPI](https://github.com/OAI/OpenAPI-Specification) | Industry-standard API spec. Foundation for agent tools. |
+| [ATXP](https://atxp.ai?utm_source=github&utm_medium=organic&utm_campaign=growth-ceo) | Agent Transaction Protocol. One-command agent identity: wallet (USDC/Base), email inbox, phone, and 100+ paid MCP tools. Self-registers — no human login required. |
 
 ---
 


### PR DESCRIPTION
## What's being added

[ATXP](https://atxp.ai) — Agent Transaction Protocol

Adds ATXP to the Protocols and Standards table. ATXP is an agent account platform that gives AI agents a funded identity in a single CLI command:

```bash
npx atxp@latest agent register
# Agent gets: USDC wallet (Base), @atxp.email inbox, $5 free credits
```

It connects to Claude Desktop, Claude Code, Cursor, Windsurf, and any MCP client as an MCP server, providing access to 100+ paid tools (web search, image gen, SMS, voice, LLM gateway) charged to the agent's own wallet balance.

**Why Protocols section:** ATXP sits alongside MCP and A2A as an agent infrastructure primitive — specifically the financial/identity layer that those protocols currently lack.

**Links:**
- Site: https://atxp.ai
- Docs: https://docs.atxp.ai
- npm: https://npmjs.com/package/atxp
- Quickstart: https://github.com/lamira-the-human/atxp-agent-quickstart