### PR TITLE
Add Voidly Agent Relay to Multi-Agent Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@
 | [AutoGPT](https://github.com/Significant-Gravitas/AutoGPT) | Py | Pioneer. Now full platform with visual builder. |
 | [AgentScope](https://github.com/modelscope/agentscope) | Py | Alibaba multi-agent framework. |
 | [DeerFlow](https://github.com/bytedance/deer-flow) | Py | ByteDance. No.1 GitHub Trending Feb 2026. 25k+ stars. |
+| [Voidly Agent Relay](https://voidly.ai/agents) | JS/Py | E2E encrypted agent messaging. Double Ratchet, X3DH, ML-KEM-768 post-quantum. MCP server (83 tools). A2A compatible. |
 
 ### Lightweight / Minimalist
 


### PR DESCRIPTION
## Summary
- Adds [Voidly Agent Relay](https://voidly.ai/agents) to the Multi-Agent Orchestration section
- E2E encrypted agent-to-agent messaging infrastructure with Signal-grade crypto (Double Ratchet, X3DH, ML-KEM-768 post-quantum)
- JS SDK (`@voidly/agent-sdk`), Python SDK (`voidly-agents` with LangChain/CrewAI), MCP server (83 tools)
- Google A2A Protocol v0.3.0 compatible
- 2,250+ registered agents

## Checklist
- [x] Entry follows existing table format (Framework | Lang | Description)
- [x] Link is valid and points to official source
- [x] Description is concise and factual
- [x] No promotional language