### PR TITLE
Add Agentify to Protocol Tooling section

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,12 @@
 | [Tool Use (Anthropic)](https://docs.anthropic.com/en/docs/build-with-claude/tool-use) | Claude native tool-use. Structured JSON. |
 | [OpenAPI](https://github.com/OAI/OpenAPI-Specification) | Industry-standard API spec. Foundation for agent tools. |
 
+### Protocol Tooling
+
+| Tool | Description |
+|------|-------------|
+| [Agentify](https://github.com/koriyoshi2041/agentify) | CLI to transform OpenAPI specs into 9 agent formats (MCP, AGENTS.md, Claude tools, etc.). `npx agentify-cli`. |
+
 ---
 
 ## 🔍 Observability and Evaluation


### PR DESCRIPTION
## What is Agentify?

[Agentify](https://github.com/koriyoshi2041/agentify) is a CLI tool that transforms OpenAPI specifications into 9 different agent interface formats:

- **MCP servers** (Model Context Protocol)
- **AGENTS.md** (OpenAI standard)
- **Claude tool definitions**
- **OpenAI function schemas**
- **LangChain tools**
- And more

## Why add it?

The list covers protocols (MCP, A2A, OpenAPI) but lacks tools that **bridge** them. Agentify fills this gap — most existing APIs have OpenAPI specs, and making them agent-native requires conversion tooling.

## Battle-tested

- Tested on GitHub's API (1,093 endpoints)
- Built-in security scanning
- MIT licensed
- `npx agentify-cli transform <spec>` — zero install needed

## Proposed change

Added a new "Protocol Tooling" subsection under Protocols and Standards.