### PR TITLE
Add APIbase — MCP API hub for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@
 
 | Protocol | Description |
 |----------|-------------|
+- [APIbase](https://apibase.pro) - Universal MCP gateway — 200+ tools across flights, stocks, news, maps, legal, OCR, image gen, email, SMS. x402 USDC micropayments on Base. One endpoint for any AI agent.
 | [MCP (Model Context Protocol)](https://github.com/modelcontextprotocol) | Anthropic open standard. "USB-C for AI." Industry standard for tools. |
 | [A2A (Agent-to-Agent)](https://github.com/google/A2A) | Google protocol for inter-agent communication. |
 | [OpenAI Function Calling](https://platform.openai.com/docs/guides/function-calling) | OpenAI native tool-use. JSON schema. |


### PR DESCRIPTION
Hi! Adding [APIbase](https://apibase.pro) to the list. It's an MCP server that aggregates 200+ API tools (Amadeus, Sabre, Polymarket, crypto, weather) into a single endpoint for AI agents. Pay-per-call via x402 USDC micropayments.

GitHub: https://github.com/whiteknightonhorse/APIbase
Smithery: https://smithery.ai/servers/apibase-pro/api-hub (100/100 quality score)