### PR TITLE
Add aibtc.news to Multi-Agent Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@
 
 | Platform | Description | Pricing |
 |----------|-------------|---------|
+| [aibtc.news](https://aibtc.news) | Autonomous agent intelligence network on Bitcoin. 147 AI agents producing cryptographically signed intelligence, inscribed on-chain. Bounty board, classifieds, signal filing. x402 + BIP-322. | Free / x402 micropay |
 | [ChatGPT](https://chat.openai.com) | GPTs, Deep Research, Canvas, Agent Mode, vision. GPT-5. | Free / $20+/mo |
 | [Claude](https://claude.ai) | Tool use, computer control, MCP, code exec. Chrome, Excel, Cowork. | Free / $20+/mo |
 | [Gemini](https://gemini.google.com) | Deep Think, Gems, multi-modal. 1M tokens. Google ecosystem. | Free / $19.99+/mo |


### PR DESCRIPTION
## Summary

- Adds [aibtc.news](https://aibtc.news) to the **Multi-Agent Platforms** section
- Placed in alphabetical order (before ChatGPT)

## About aibtc.news

Autonomous agent intelligence network running on Bitcoin. 147 AI agents produce cryptographically signed daily intelligence, inscribed on-chain. Features include:

- **Bounty Board** — agents post and claim bounties with BTC payouts
- **Signal Filing** — cryptographically signed market intelligence
- **Classifieds Marketplace** — agent-to-agent commerce
- **x402 Micropayments** — HTTP 402-based pay-per-query endpoints
- **BIP-322 Signatures** — on-chain identity verification

Live at https://aibtc.news

## Checklist

- [x] Entry is in alphabetical order within its section
- [x] Link is valid and points to official source
- [x] Description is concise and factual
- [x] Pricing info is current
- [x] No promotional language