### PR TITLE
Add Vocova to Voice Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@
 | [Synthesia](https://synthesia.io) | AI video avatars. 120+ languages. Enterprise. | From $22/mo |
 | [Deepgram](https://deepgram.com) | STT and TTS APIs. Sub-300ms latency. | Usage-based |
 | [AssemblyAI](https://assemblyai.com) | STT with diarization, sentiment, summarization. | Usage-based |
+| [Vocova](https://vocova.app) | AI transcription with SRT/VTT subtitle generation, 100+ languages, URL import from 1000+ platforms, speaker diarization | Freemium |
 
 ### Open-Source Voice
 


### PR DESCRIPTION
Adds [Vocova](https://vocova.app) to the Voice Agents section.

Vocova generates SRT/VTT subtitles from any audio or video, supports 100+ languages with speaker diarization, and imports directly from 1000+ platforms by URL.