### PR TITLE
Add Miyabi — TypeScript multi-agent orchestration framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@
 | [AutoGen](https://github.com/microsoft/autogen) | Py | Microsoft multi-agent conversations. |
 | [CrewAI](https://github.com/crewAIInc/crewAI) | Py | Role-based crew members with goals and tools. |
 | [MetaGPT](https://github.com/geekan/MetaGPT) | Py | PM, architect, engineer roles. Software company sim. |
+| [Miyabi](https://github.com/ShunsukeHayashi/Miyabi) | TS | Issue-Driven Development. 7 coding + 14 business agents. MCP 172+ tools. GitHub as OS. |
 | [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) | Py | Official. Multi-step agents with handoffs. |
 | [Google ADK](https://github.com/google/adk-python) | Py | Native Gemini. Multi-agent orchestration. |
 | [Strands Agents](https://github.com/strands-agents/sdk-python) | Py | AWS-backed. Model-driven tool use. |


### PR DESCRIPTION
## Addition

**Miyabi** — added to the **Multi-Agent Orchestration** section (alphabetical order between MetaGPT and OpenAI Agents SDK).

## About Miyabi

- **GitHub**: https://github.com/ShunsukeHayashi/Miyabi
- **npm**: https://www.npmjs.com/package/miyabi
- **Language**: TypeScript
- **License**: Apache 2.0
- **Actively maintained**: Yes (latest commit: March 2026)

### Key Features
- Issue-Driven Development: Write a GitHub Issue, 7 AI agents autonomously implement, review, test, and create a PR
- 172+ MCP tools integrated (miyabi-mcp-bundle)
- 110+ Agent Skills via Agent Skill Bus
- GitHub as OS: 53 labels, 24 workflows, Projects V2 integration
- Distributed cluster execution (up to 6 machines)
- Quality gate: auto-review with 80+ score threshold

### Checklist
- [x] Entry is in alphabetical order within its section
- [x] Link is valid and points to official source
- [x] Description is concise and factual
- [x] No promotional language
- [x] Actively maintained