### PR TITLE
Add Global Chat — cross-protocol agent discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@
 |----------|-------------|
 | [MCP (Model Context Protocol)](https://github.com/modelcontextprotocol) | Anthropic open standard. "USB-C for AI." Industry standard for tools. |
 | [A2A (Agent-to-Agent)](https://github.com/google/A2A) | Google protocol for inter-agent communication. |
+| [Global Chat](https://global-chat.io) | Cross-protocol agent discovery. Search 18K+ MCP servers across 6+ registries. A2A, agents.txt support. Free. OSS. |
 | [OpenAI Function Calling](https://platform.openai.com/docs/guides/function-calling) | OpenAI native tool-use. JSON schema. |
 | [Tool Use (Anthropic)](https://docs.anthropic.com/en/docs/build-with-claude/tool-use) | Claude native tool-use. Structured JSON. |
 | [OpenAPI](https://github.com/OAI/OpenAPI-Specification) | Industry-standard API spec. Foundation for agent tools. |


### PR DESCRIPTION
Adds [Global Chat](https://global-chat.io) to the **Protocols and Standards** section.

Global Chat is a cross-protocol agent discovery platform — a search engine for AI agents and MCP servers across 6+ registries (mcp.so, Glama.ai, Smithery, Cursor Directory, and more). It aggregates 18,000+ MCP servers and supports MCP, A2A, and agents.txt protocols.

- Website: https://global-chat.io
- GitHub: https://github.com/pumanitro/global-chat
- npm MCP server: `@global-chat/mcp-server`
- Free and open source (MIT)

Placed alphabetically between A2A and OpenAI Function Calling. Follows existing table format.