### PR TITLE
Add OpenClaw agent templates (177 production-ready SOUL.md configs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@
 | [Portia AI](https://github.com/portia-ai/portia-sdk-python) | Py | Reliable agents in production. |
 | [MicroAgent](https://github.com/aymenfurter/microagent) | Py | Self-editing prompts and code. |
 
+### Agent Templates
+
+| Collection | Description |
+|------------|-------------|
+| [OpenClaw Agent Templates](https://github.com/mergisi/awesome-openclaw-agents) | 177 production-ready SOUL.md configs across 24 categories (PM, SEO, DevOps, Writer, Support). Copy-paste ready for [OpenClaw](https://github.com/openclaw/openclaw). Visual deploy via [CrewClaw](https://crewclaw.com). |
+
 ---
 
 ## 🌐 Browser and Desktop Agents


### PR DESCRIPTION
## What is this?

Adding [OpenClaw Agent Templates](https://github.com/mergisi/awesome-openclaw-agents) as a new "Agent Templates" subsection under Agent Frameworks.

## Why it belongs here

- **177 production-ready** SOUL.md agent configurations, not toy examples
- **24 categories**: PM, SEO, DevOps, Writer, Support, Sales, Security, Data, and more
- **Copy-paste ready**: Each template includes structured persona definitions, tool bindings, memory rules, and heartbeat schedules
- Built for the [OpenClaw](https://github.com/openclaw/openclaw) agent framework (already listed in the Self-Hosted section of this list)
- Visual deployment available via [CrewClaw](https://crewclaw.com) for one-click setup

The entry uses the existing table format and adds a new "Agent Templates" subcategory under Agent Frameworks.