### PR TITLE
Add AI for Database to Data Analysis section

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@
 
 | Agent | Description | Pricing |
 |-------|-------------|---------|
+| [AI for Database](https://aifordatabase.com) | Connect to any database and interact with it in plain English. No SQL needed — get instant insights, build self-refreshing dashboards, and trigger automated workflows based on database changes. | Free / Paid |
 | [Julius AI](https://julius.ai) | Upload CSV/Excel, ask in natural language. | Free / Paid |
 | [Hex AI](https://hex.tech) | Collaborative data platform. AI analysis. | Free / Paid |
 | [PandasAI](https://github.com/Sinaptik-AI/pandas-ai) | Chat with your data. NL to Pandas/SQL. | Free (OSS) |


### PR DESCRIPTION
## Summary

Adds **[AI for Database](https://aifordatabase.com)** to the Data Analysis subsection under Data and Research Agents.

**Tool details:**
- **Name:** AI for Database
- **URL:** https://aifordatabase.com
- **Description:** Connect to any database and interact with it in plain English. No SQL needed — get instant insights, build self-refreshing dashboards, and trigger automated workflows based on database changes.
- **Category:** Data/Analytics agents, productivity, business intelligence

## Checklist
- [x] Entry is in alphabetical order within its section
- [x] Link is valid and points to official source
- [x] Description is concise and factual
- [x] Pricing info is current
- [x] No promotional language