### PR TITLE
Add KinBot - self-hosted AI agent platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@
 | [OpenClaw](https://github.com/openclaw/openclaw) | Fastest-growing GitHub repo ever (9k to 188k stars in 60 days). Self-hosted agent across WhatsApp, Telegram, Slack, Discord, Signal. 5,700+ community skills. |
 | [LibreChat](https://github.com/danny-avila/LibreChat) | Self-hosted multi-model chat. All major providers. |
 | [LobeChat](https://github.com/lobehub/lobe-chat) | OSS ChatGPT/Gemini UI. Plugin system. Multi-modal. |
+| [KinBot](https://github.com/MarlBurroW/kinbot) | Self-hosted AI agent platform. Persistent memory (hybrid search + LLM re-ranking), 23+ providers (including Ollama), plugin store, mini-apps SDK, cron scheduling, 6 messaging channels. SQLite, runs on a Pi. |
 | [Anything LLM](https://github.com/Mintplex-Labs/anything-llm) | All-in-one AI app. RAG, agents. Desktop + Docker. |
 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | Data interaction with local LLM. 100% private. |
 


### PR DESCRIPTION
Hey! Adding [KinBot](https://github.com/MarlBurroW/kinbot) to the **Self-Hosted Agents and UIs** section.

KinBot is a self-hosted AI agent platform with:
- Persistent memory with hybrid search (FTS + vector) and LLM re-ranking
- 23+ LLM providers including Ollama for fully local setups
- 6 messaging channels: Telegram, Discord, Slack, WhatsApp, Signal, Matrix
- Plugin store with hot-reload, mini-apps SDK, cron scheduling
- Runs on SQLite, lightweight enough for a Raspberry Pi

Open source (AGPL-3.0), actively maintained.