### PR TITLE
Add MHN AI Agent Memory — Hopfield network-based agent memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@
 | [RAGFlow](https://github.com/infiniflow/ragflow) | OSS RAG engine with agent capabilities. |
 | [Pathway](https://github.com/pathwaycom/pathway) | Live data RAG. Real-time streaming. 50k+ stars. |
 | [Mem0](https://github.com/mem0ai/mem0) | Memory layer for agents. Long-term across sessions. |
+| [MHN AI Agent Memory](https://github.com/shahzebqazi/mhn-ai-agent-memory) | Associative agent memory via Modern Hopfield Networks. No LLM calls or external DB; retrieval is a matrix multiply. |
 | [Chroma](https://github.com/chroma-core/chroma) | OSS embedding database. Fastest way to build RAG. |
 | [Weaviate](https://github.com/weaviate/weaviate) | OSS vector DB. GraphQL. Multi-modal search. |
 | [Qdrant](https://github.com/qdrant/qdrant) | High-performance vector DB in Rust. |


### PR DESCRIPTION
MHN AI Agent Memory provides associative memory for AI agents using Modern Hopfield Networks. It does not rely on LLM calls or an external database: memory operations reduce to a matrix multiply for fast pattern retrieval.

Repository: https://github.com/shahzebqazi/mhn-ai-agent-memory

Made with [Cursor](https://cursor.com)