### PR TITLE
Add CoWorker Protocol to Protocols and Standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@
 | [OpenAI Function Calling](https://platform.openai.com/docs/guides/function-calling) | OpenAI native tool-use. JSON schema. |
 | [Tool Use (Anthropic)](https://docs.anthropic.com/en/docs/build-with-claude/tool-use) | Claude native tool-use. Structured JSON. |
 | [OpenAPI](https://github.com/OAI/OpenAPI-Specification) | Industry-standard API spec. Foundation for agent tools. |
+| [CoWorker Protocol](https://github.com/ZiwayZhao/agent-coworker) | P2P agent collaboration over XMTP. Schema-based skill invocation, E2E encryption, revocable trust. Decentralized — no central server. |
 
 ---
 


### PR DESCRIPTION
Adds [CoWorker Protocol](https://github.com/ZiwayZhao/agent-coworker) to the Protocols and Standards section.

CoWorker fills a gap in the current protocol landscape — it's a decentralized agent-to-agent collaboration protocol over XMTP:

- MCP connects agents to **tools**
- A2A connects agents inside **enterprises** (HTTP-based)
- CoWorker connects agents across the **open internet** (P2P, E2E encrypted)

Key characteristics:
- Schema-based skill invocation (agents see input/output contracts, not code)
- Revocable trust tiers with automatic downgrade
- No central server — XMTP production network
- MIT licensed, zero deps, `pip install agent-coworker`