### PR TITLE
Add Cortex — open protocol for AI agent coordination

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@
 | [OpenAI Function Calling](https://platform.openai.com/docs/guides/function-calling) | OpenAI native tool-use. JSON schema. |
 | [Tool Use (Anthropic)](https://docs.anthropic.com/en/docs/build-with-claude/tool-use) | Claude native tool-use. Structured JSON. |
 | [OpenAPI](https://github.com/OAI/OpenAPI-Specification) | Industry-standard API spec. Foundation for agent tools. |
+| [Cortex](https://github.com/agentweave/cortex) | Open protocol for AI agent team coordination via markdown. Chief-of-staff pattern. Runtime-agnostic (Claude Code, Codex, Cursor, Gemini CLI, OpenCode). |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds [Cortex](https://github.com/agentweave/cortex) to the **Protocols and Standards** section
- Cortex is an open protocol for coordinating AI agent teams through plain markdown files
- Chief-of-staff pattern — one coordinator manages workers
- Runtime-agnostic: works with Claude Code, Codex, Cursor, Gemini CLI, OpenCode
- MIT licensed

🤖 Generated with [Claude Code](https://claude.com/claude-code)