### PR TITLE
Add Signbee MCP to Protocol Tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@
 | Tool | Description |
 |------|-------------|
 | [Agentify](https://github.com/koriyoshi2041/agentify) | CLI to transform OpenAPI specs into 9 agent formats (MCP, AGENTS.md, Claude tools, etc.). `npx agentify-cli`. |
+| [Signbee MCP](https://www.npmjs.com/package/signbee-mcp) | E-signature MCP server. Agents send contracts for legally binding signing with SHA-256 certificates. `npx signbee-mcp`. |
 
 ---
 


### PR DESCRIPTION
Adds signbee-mcp to the Protocol Tooling table.

E-signature MCP server that enables agents to send documents for legally binding signing with SHA-256 audit certificates. Install via `npx signbee-mcp`.

Fits alongside Agentify as a protocol-level tool that agents compose into deal-closing or contract workflows.