### PR TITLE
Add Typer - free local AI chat for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@
 | [KinBot](https://github.com/MarlBurroW/kinbot) | Self-hosted AI agent platform. Persistent memory (hybrid search + LLM re-ranking), 23+ providers (including Ollama), plugin store, mini-apps SDK, cron scheduling, 6 messaging channels. SQLite, runs on a Pi. |
 | [Anything LLM](https://github.com/Mintplex-Labs/anything-llm) | All-in-one AI app. RAG, agents. Desktop + Docker. |
 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | Data interaction with local LLM. 100% private. |
+| [Typer](https://typer.space) | Free local AI chat for macOS (Apple Silicon). Runs entirely on-device. No account, no cloud, no ads. Offline web search included. |
 
 ---
 


### PR DESCRIPTION
Typer is a free local AI chat app for macOS (Apple Silicon) that runs entirely on-device with no account, no cloud, and no ads. It works fully offline, includes on-device web search, and auto-updates models as they improve.

It fits the Local and Self-Hosted AI section as a polished consumer-facing local AI client, complementing the existing self-hosted UIs with a zero-setup Mac App Store option.