### PR TITLE
Add Cloclo to Terminal and CLI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 | [Kilo Code](https://kilocode.ai) | Structured modes. Tighter context. | Free + API |
 | [OpenCode](https://github.com/opencode-ai/opencode) | BYOK terminal agent for Cursor refugees. | Free + API |
 | [Caliber](https://github.com/caliber-ai-org/ai-setup) | CLI that fingerprints projects and generates/syncs AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md). Scores quality. | Free + API |
+| [Cloclo](https://www.npmjs.com/package/cloclo) | Multi-agent runtime for 13 LLM providers. AICL protocol for agent coordination. Native CDP browser, docs, voice/phone tools. Skill registry. NDJSON bridge. | Free (OSS) |
 
 ### Autonomous Software Engineers
 


### PR DESCRIPTION
Adding [Cloclo](https://www.npmjs.com/package/cloclo) to the Terminal and CLI Agents section.

**What it is:** An open-source multi-agent runtime for 13 LLM providers (Anthropic, OpenAI, Google, DeepSeek, Mistral, Groq + local: Ollama, LM Studio, vLLM, Jan, llama.cpp). MIT licensed, zero native deps.

**Why it belongs:** It's actively maintained (latest release v2.0.0, April 2026), publicly available on npm, and fills a unique niche as an agent runtime (vs IDE or standalone CLI) with AICL protocol for multi-agent coordination.

- npm: https://www.npmjs.com/package/cloclo
- GitHub: https://github.com/seifbenayed/claude-code-sdk