### PR TITLE
Add Praman — AI-first SAP UI5 test automation for Playwright

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@
 | [Amazon Nova Act](https://aws.amazon.com/ai/nova/) | AWS browser automation. Enterprise reliability. |
 | [Plasmate](https://github.com/plasmate-labs/plasmate) | Headless browser compiling HTML to structured JSON (SOM). 17.5x compression, 13 MCP tools. First browser tool on MCP Registry. Rust, Apache-2.0. |
 | [Playwright MCP](https://github.com/microsoft/playwright-mcp) | MCP server for Playwright + AI agents. |
+| [Praman](https://praman.dev) | AI-first SAP UI5/Fiori test automation for Playwright. 199 typed control proxies, Claude Code agents for plan-generate-heal. Apache-2.0. |
 | [onUI](https://github.com/onllm-dev/onUI) | OSS browser extension and MCP server for annotation-first UI pair programming with AI agents. Chrome, Edge, Firefox. Privacy-first, local only. |
 
 ---


### PR DESCRIPTION
## What is Praman?

[Praman](https://praman.dev) (`playwright-praman`) is an open-source Playwright plugin for SAP UI5/Fiori test automation.

- **199 typed control proxies** covering all major SAP UI5 control libraries
- **OData V2/V4** service testing support
- **Fiori Elements** page-object patterns
- **Claude Code AI agents** — planner, generator, and healer for automated test creation
- **6 auth strategies** for SAP systems

## Links

- **Website:** https://praman.dev
- **npm:** [`playwright-praman`](https://www.npmjs.com/package/playwright-praman)
- **GitHub:** [mrkanitkar/playwright-praman](https://github.com/mrkanitkar/playwright-praman)
- **License:** Apache-2.0

## Checklist

- [x] Entry placed alphabetically (after Playwright MCP, before onUI)
- [x] Link points to official website
- [x] Description is concise and factual (1-2 sentences)
- [x] No promotional language
- [x] Project is actively maintained (last published April 2026)