### PR TITLE
Add Agent Brain to RAG and Knowledge Bases

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@
 | [Lorg](https://github.com/LorgAI/lorg-mcp-server) — Permanent intelligence archive for AI agents. Structured contributions (prompts, workflows, insights, patterns) pass an automated quality gate and are hash-chained. Trust scores are cryptographically backed and publicly auditable. Works with Claude and ChatGPT.
 | [Pathway](https://github.com/pathwaycom/pathway) | Live data RAG. Real-time streaming. 50k+ stars. |
 | [Mem0](https://github.com/mem0ai/mem0) | Memory layer for agents. Long-term across sessions. |
+| [Agent Brain](https://github.com/kaderosio/agent-brain) | 7-layer cognitive memory. Perception gate, dream cycle, predictive. Self-hostable. |
 | [Nex](https://github.com/nex-crm/nex-as-a-skill) | Organizational context and memory for AI agents. 60-tool MCP server, 100+ integrations. |
 | [Chroma](https://github.com/chroma-core/chroma) | OSS embedding database. Fastest way to build RAG. |
 | [Weaviate](https://github.com/weaviate/weaviate) | OSS vector DB. GraphQL. Multi-modal search. |


### PR DESCRIPTION
Adds [Agent Brain](https://github.com/kaderosio/agent-brain) to the RAG and Knowledge Bases section alongside Mem0.

Agent Brain is an open-source 7-layer cognitive memory system for AI agents with perception gate, dream cycle, and predictive capabilities. Self-hostable via Docker.