### PR TITLE
Add Uni-CLI to Developer Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@
 | [Plasmate](https://github.com/plasmate-labs/plasmate) | Headless browser compiling HTML to structured JSON (SOM). 17.5x compression, 13 MCP tools. First browser tool on MCP Registry. Rust, Apache-2.0. |
 | [Playwright MCP](https://github.com/microsoft/playwright-mcp) | MCP server for Playwright + AI agents. |
 | [onUI](https://github.com/onllm-dev/onUI) | OSS browser extension and MCP server for annotation-first UI pair programming with AI agents. Chrome, Edge, Firefox. Privacy-first, local only. |
+| [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) | Universal CLI for AI agents — 756 commands across 167 sites. Self-repairing YAML adapters, auto-JSON, ~80 tokens/call. TypeScript, Apache-2.0. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@
 | [Plasmate](https://github.com/plasmate-labs/plasmate) | Headless browser compiling HTML to structured JSON (SOM). 17.5x compression, 13 MCP tools. First browser tool on MCP Registry. Rust, Apache-2.0. |
 | [Playwright MCP](https://github.com/microsoft/playwright-mcp) | MCP server for Playwright + AI agents. |
 | [onUI](https://github.com/onllm-dev/onUI) | OSS browser extension and MCP server for annotation-first UI pair programming with AI agents. Chrome, Edge, Firefox. Privacy-first, local only. |
-| [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) | Universal CLI for AI agents — 756 commands across 167 sites. Self-repairing YAML adapters, auto-JSON, ~80 tokens/call. TypeScript, Apache-2.0. |
+| [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) | Universal CLI for AI agents — 1,458 commands across 238 sites. Self-repairing YAML adapters with structured error envelopes, auto-JSON output; per-call token budget in `docs/BENCHMARK.md`. TypeScript, Apache-2.0. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@
 | [Plasmate](https://github.com/plasmate-labs/plasmate) | Headless browser compiling HTML to structured JSON (SOM). 17.5x compression, 13 MCP tools. First browser tool on MCP Registry. Rust, Apache-2.0. |
 | [Playwright MCP](https://github.com/microsoft/playwright-mcp) | MCP server for Playwright + AI agents. |
 | [onUI](https://github.com/onllm-dev/onUI) | OSS browser extension and MCP server for annotation-first UI pair programming with AI agents. Chrome, Edge, Firefox. Privacy-first, local only. |
-| [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) | Universal CLI for AI agents — 1,458 commands across 238 sites. Self-repairing YAML adapters with structured error envelopes, auto-JSON output; per-call token budget in `docs/BENCHMARK.md`. TypeScript, Apache-2.0. |
+| [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) | Universal CLI for AI agents — exposes web, desktop, Electron apps as deterministic commands. Self-repairing YAML adapters with structured error envelopes, auto-JSON output. Live catalog size and per-call token budget tracked in the repo's README and `docs/BENCHMARK.md`. TypeScript, Apache-2.0. |
 
 ---
 


### PR DESCRIPTION
## Add Uni-CLI

[Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) is a universal CLI for AI agents — 756 commands across 167 sites (web, desktop, Electron apps). Self-repairing 20-line YAML adapters, auto-JSON output, ~80 tokens per call. TypeScript, Apache-2.0.

**Why it fits this list:** Uni-CLI is developer infrastructure for browser and desktop agents. It provides a CLI execution layer with raw CDP browser control, letting agents interact with any application. Added to the **Browser & Desktop Agents > Developer Infrastructure** table.

- npm: `@zenalexa/unicli`
- GitHub: https://github.com/olo-dot-io/Uni-CLI