### PR TITLE
Add amux — open-source Claude Code agent multiplexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@
 | [Grok](https://x.ai) | Real-time X data. Grok 4.20. Multi-agent Society of Mind. Image gen. | X Premium+ |
 | [Meta AI](https://meta.ai) | Llama-powered. WhatsApp/Messenger. Manus acquisition. | Free |
 | [TeamHero](https://github.com/sagiyaacoby/TeamHero) | Open-source multi-agent orchestration with web dashboard, task lifecycle, knowledge base, and autopilot mode. Built on Claude Code. Runs locally. | Free (OSS) |
+| [amux](https://github.com/esteininger/amux) | Open-source agent multiplexer for running dozens of parallel Claude Code sessions. Web dashboard, self-healing watchdog, kanban board, agent-to-agent REST API, mobile PWA. Python 3 + tmux. | Free (OSS) |
 | [Microsoft Copilot](https://copilot.microsoft.com) | Office 365 integration. Enterprise. | Free / $30/user |
 | [Coze](https://coze.com) | ByteDance agent builder. Visual workflow. Plugin marketplace. | Free / Paid |
 | [Cursor AI Automated Team](https://github.com/joinwell52-AI/joinwell52) | 4-role AI team (PM+DEV+OPS+QA) in Cursor IDE. File-based task routing, auto patrol bot. 87 person-days in 17 days. | Free / OSS |

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@
 | [Grok](https://x.ai) | Real-time X data. Grok 4.20. Multi-agent Society of Mind. Image gen. | X Premium+ |
 | [Meta AI](https://meta.ai) | Llama-powered. WhatsApp/Messenger. Manus acquisition. | Free |
 | [TeamHero](https://github.com/sagiyaacoby/TeamHero) | Open-source multi-agent orchestration with web dashboard, task lifecycle, knowledge base, and autopilot mode. Built on Claude Code. Runs locally. | Free (OSS) |
-| [amux](https://github.com/esteininger/amux) | Open-source agent multiplexer for running dozens of parallel Claude Code sessions. Web dashboard, self-healing watchdog, kanban board, agent-to-agent REST API, mobile PWA. Python 3 + tmux. | Free (OSS) |
+| [amux](https://github.com/mixpeek/amux) | Open-source agent multiplexer for running dozens of parallel Claude Code sessions. Web dashboard, self-healing watchdog, kanban board, agent-to-agent REST API, mobile PWA. Python 3 + tmux. | Free (OSS) |
 | [Microsoft Copilot](https://copilot.microsoft.com) | Office 365 integration. Enterprise. | Free / $30/user |
 | [Coze](https://coze.com) | ByteDance agent builder. Visual workflow. Plugin marketplace. | Free / Paid |
 | [Cursor AI Automated Team](https://github.com/joinwell52-AI/joinwell52) | 4-role AI team (PM+DEV+OPS+QA) in Cursor IDE. File-based task routing, auto patrol bot. 87 person-days in 17 days. | Free / OSS |


### PR DESCRIPTION
## Summary

- Adds [amux](https://github.com/mixpeek/amux) to the **Multi-Agent Platforms** section
- amux is an open-source agent multiplexer for running dozens of parallel Claude Code sessions with a web dashboard, self-healing watchdog, kanban board, agent-to-agent REST API, and mobile PWA. Python 3 + tmux.

Thanks for maintaining this list!