### PR TITLE
Add Agentic Engineering Jobs to Newsletters and Communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,6 +617,7 @@
 | [r/LangChain](https://reddit.com/r/LangChain) | Agent developer community |
 | [r/ClaudeAI](https://reddit.com/r/ClaudeAI) | Claude community |
 | [r/LocalLLaMA](https://reddit.com/r/LocalLLaMA) | Self-hosted LLM community |
+| [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) | Job board for engineers building agentic systems (RAG, AI agents, LLM-powered products, agent orchestration). Free to post and browse. |
 
 ---
 


### PR DESCRIPTION
Adding https://agentic-engineering-jobs.com to the Newsletters and Communities section.

It's a job board for engineers building agentic systems — RAG pipelines, AI agents, LLM-powered products, agent orchestration. Felt like a natural fit alongside the other community/news resources in this section.

- 500+ active listings
- Free to post for companies, free to browse for job seekers