### PR TITLE
Add Dexto - Open agent harness with coding agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@
 | [Devin](https://devin.ai) | Cognition. Fully autonomous. Sandboxed cloud env. Devin 2.0 with Interactive Planning. | $20/mo + ACU |
 | [Copilot Workspace](https://githubnext.com/projects/copilot-workspace) | GitHub issue-to-PR agent. | Copilot sub |
 | [SWE-Agent](https://github.com/princeton-nlp/SWE-agent) | Princeton. Resolves real GitHub issues autonomously. | Free (OSS) |
+| [Dexto](https://github.com/truffle-ai/dexto) | Open agent harness with production-ready coding agent. YAML config, 50+ LLM support, MCP tools, persistent memory. | Free |
 | [OpenHands](https://github.com/All-Hands-AI/OpenHands) | OSS autonomous software engineer (ex-OpenDevin). | Free (OSS) |
 | [Grok Build (xAI)](https://x.ai) | 8 parallel agents for code gen. Multi-agent "Society of Mind" architecture. | xAI sub |
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 | [Kilo Code](https://kilocode.ai) | Structured modes. Tighter context. | Free + API |
 | [OpenCode](https://github.com/opencode-ai/opencode) | BYOK terminal agent for Cursor refugees. | Free + API |
 | [Caliber](https://github.com/caliber-ai-org/ai-setup) | CLI that fingerprints projects and generates/syncs AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md). Scores quality. | Free + API |
+| [Dexto](https://github.com/truffle-ai/dexto) | Open agent harness with production-ready coding agent. YAML config, 50+ LLM support, MCP tools, persistent memory. | Free |
 
 ### Autonomous Software Engineers
 
@@ -88,7 +89,6 @@
 | [Devin](https://devin.ai) | Cognition. Fully autonomous. Sandboxed cloud env. Devin 2.0 with Interactive Planning. | $20/mo + ACU |
 | [Copilot Workspace](https://githubnext.com/projects/copilot-workspace) | GitHub issue-to-PR agent. | Copilot sub |
 | [SWE-Agent](https://github.com/princeton-nlp/SWE-agent) | Princeton. Resolves real GitHub issues autonomously. | Free (OSS) |
-| [Dexto](https://github.com/truffle-ai/dexto) | Open agent harness with production-ready coding agent. YAML config, 50+ LLM support, MCP tools, persistent memory. | Free |
 | [OpenHands](https://github.com/All-Hands-AI/OpenHands) | OSS autonomous software engineer (ex-OpenDevin). | Free (OSS) |
 | [Grok Build (xAI)](https://x.ai) | 8 parallel agents for code gen. Multi-agent "Society of Mind" architecture. | xAI sub |
 


### PR DESCRIPTION
## Add Dexto

Adding [Dexto](https://github.com/truffle-ai/dexto) to the CLI Coding Agent section.

**Description:** Open agent harness that ships with a production-ready coding agent. YAML config, 50+ LLM support, MCP tools, persistent memory.

**Category:** CLI Coding Agent

**Pricing:** Free

**Links:**
- [GitHub](https://github.com/truffle-ai/dexto)
- [Website](https://dexto.ai)