### PR TITLE
Add TraceCC to RAG and Knowledge Bases

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@
 | [Pathway](https://github.com/pathwaycom/pathway) | Live data RAG. Real-time streaming. 50k+ stars. |
 | [Mem0](https://github.com/mem0ai/mem0) | Memory layer for agents. Long-term across sessions. |
 | [Nex](https://github.com/nex-crm/nex-as-a-skill) | Organizational context and memory for AI agents. 60-tool MCP server, 100+ integrations. |
+| [TraceCC](https://github.com/lludlow/TraceCC) | CLI-native long-term memory for AI agents. Compiles session traces (Claude, Codex) into searchable SQLite bundles. BM25 + regex, token-efficient recall without summarization loss. |
 | [Chroma](https://github.com/chroma-core/chroma) | OSS embedding database. Fastest way to build RAG. |
 | [Weaviate](https://github.com/weaviate/weaviate) | OSS vector DB. GraphQL. Multi-modal search. |
 | [Qdrant](https://github.com/qdrant/qdrant) | High-performance vector DB in Rust. |


### PR DESCRIPTION
## Summary

- Adds [TraceCC](https://github.com/lludlow/TraceCC) to the **RAG and Knowledge Bases** section
- CLI-native long-term memory for AI agents over their own session history
- Compiles raw session traces (Claude Code, Codex) into searchable SQLite bundles
- BM25 and regex search with token-efficient retrieval -- no summarization loss
- Placed after Mem0 and Nex (memory tools), before the vector DB entries

## Checklist

- [x] Link is valid and points to official source
- [x] Repo is public and actively maintained
- [x] Description is concise and factual
- [x] No promotional language
- [x] Entry placed in appropriate section