### PR TITLE
Add HelloChusquis to Terminal and CLI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 | [Kilo Code](https://kilocode.ai) | Structured modes. Tighter context. | Free + API |
 | [OpenCode](https://github.com/opencode-ai/opencode) | BYOK terminal agent for Cursor refugees. | Free + API |
 | [Caliber](https://github.com/caliber-ai-org/ai-setup) | CLI that fingerprints projects and generates/syncs AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md). Scores quality. | Free + API |
+| [HelloChusquis](https://github.com/aminoy77/HelloChusquis) | Terminal AI agent with multi-provider fallback (15+ providers), plugin system, persistent memory, auto-learning, task planner and web interface. | Free & Open Source |
 
 ### Autonomous Software Engineers
 


### PR DESCRIPTION
## What does this PR do?

Adds **HelloChusquis** to the Terminal and CLI Agents section.

## Project Information

- **Repository**: https://github.com/aminoy77/HelloChusquis
- **Description**: Terminal AI agent with multi-provider fallback (30+ providers), plugin system, persistent memory, auto-learning, task planner and web interface.
- **License**: MIT
- **Stars**: (current)
- **PyPI**: https://pypi.org/project/hellochusquis/

## Why it fits

It's an actively maintained open-source terminal-first AI agent released in 2025-2026 with real features (plugins, file generation, browser control, etc.).

---

Thank you!