### PR TITLE
Add Helium MCP to Protocol Tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@
 | Tool | Description |
 |------|-------------|
 | [Agentify](https://github.com/koriyoshi2041/agentify) | CLI to transform OpenAPI specs into 9 agent formats (MCP, AGENTS.md, Claude tools, etc.). `npx agentify-cli`. |
+| [Helium MCP](https://github.com/connerlambden/helium-mcp) | MCP server for real-time news with bias scoring across 5,000+ sources, balanced news synthesis, AI-powered options pricing, live market data, and meme search. 9 tools, streamable HTTP. [Product page](https://heliumtrades.com/mcp-page/). 50 free queries, no signup. |
 
 ---
 


### PR DESCRIPTION
## Summary
Adds **[Helium MCP](https://github.com/connerlambden/helium-mcp)** under **Protocols and Standards → Protocol Tooling**, alongside other MCP-oriented tooling (e.g. Agentify).

## Resource
- **Name:** Helium MCP
- **GitHub:** https://github.com/connerlambden/helium-mcp
- **Website:** https://heliumtrades.com/mcp-page/
- **What it is:** MCP server for real-time news with bias scoring (5,000+ sources), balanced news synthesis, AI-powered options pricing, live market data, and meme search. 9 tools, streamable HTTP. 50 free queries, no signup.

## Checklist (per CONTRIBUTING.md)
- [x] Entry placed in the appropriate section (Protocol Tooling / MCP)
- [x] Alphabetical order within the subsection (after Agentify)
- [x] Links point to official sources
- [x] Concise, factual description; pricing noted in prose

Made with [Cursor](https://cursor.com)