### PR TITLE
Add Octopal to multi-agent platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@
 | [Grok](https://x.ai) | Real-time X data. Grok 4.20. Multi-agent Society of Mind. Image gen. | X Premium+ |
 | [Meta AI](https://meta.ai) | Llama-powered. WhatsApp/Messenger. Manus acquisition. | Free |
 | [TeamHero](https://github.com/sagiyaacoby/TeamHero) | Open-source multi-agent orchestration with web dashboard, task lifecycle, knowledge base, and autopilot mode. Built on Claude Code. Runs locally. | Free (OSS) |
+| [Octopal](https://github.com/pmbstyle/Octopal) | Open-source local multi-agent runtime with isolated workers, policy-controlled execution, MCP/tools support, recurring tasks, and a private dashboard. Security-first by design. | Free (OSS) |
 | [Microsoft Copilot](https://copilot.microsoft.com) | Office 365 integration. Enterprise. | Free / $30/user |
 | [Coze](https://coze.com) | ByteDance agent builder. Visual workflow. Plugin marketplace. | Free / Paid |
 | [Cursor AI Automated Team](https://github.com/joinwell52-AI/joinwell52) | 4-role AI team (PM+DEV+OPS+QA) in Cursor IDE. File-based task routing, auto patrol bot. 87 person-days in 17 days. | Free / OSS |


### PR DESCRIPTION
## Summary
- add Octopal under Multi-Agent Platforms
- describe its local, security-first runtime and dashboard

## Why
Octopal is an open-source multi-agent platform for autonomous local operation with isolated workers and policy-controlled execution.