### PR TITLE
Add Not Human Search to Protocol Tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@
 | Tool | Description |
 |------|-------------|
 | [Agentify](https://github.com/koriyoshi2041/agentify) | CLI to transform OpenAPI specs into 9 agent formats (MCP, AGENTS.md, Claude tools, etc.). `npx agentify-cli`. |
+| [Not Human Search](https://nothumansearch.ai) | Search engine indexing 700+ agent-first tools, ranked by agentic-readiness signals (llms.txt, OpenAPI, MCP server, ai-plugin.json). Hosted MCP at `https://nothumansearch.ai/mcp` (streamable-http) lets agents discover agent-accessible tools at runtime. |
 
 ---
 


### PR DESCRIPTION
Adding [Not Human Search](https://nothumansearch.ai) to the Protocol Tooling section.

NHS is an MCP server that indexes 700+ agent-first tools, ranked by agentic-readiness signals (llms.txt, OpenAPI, MCP server, ai-plugin.json, schema.org). Agents can wire it in at build time:

```bash
claude mcp add --transport http nothumansearch https://nothumansearch.ai/mcp
```

**Fits Protocol Tooling because:** it's infrastructure for agent-discovery — the tool agents call when they need to find other agent-accessible tools. Alongside Agentify (which generates agent formats from OpenAPI), NHS is the discovery surface for what's already out there.

Also exposes a REST API at `/api/v1/*` for non-MCP agents.

Happy to move it to a different section if you'd prefer — could also fit Data and Research Agents.