### PR TITLE
Add ClawBench to Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@
 | [AgentBench](https://github.com/THUDM/AgentBench) | 8-environment LLM agent benchmark. |
 | [Terminal-Bench](https://terminalbench.com) | Terminal agent performance. GPT-5.4 leads at 77.3%. |
 | [ARC-AGI-2](https://arcprize.org) | ⭐ New frontier benchmark. Gemini 3.1 Pro leads. |
+| [ClawBench](https://github.com/reacher-z/ClawBench) | Browser agents on live production websites. 153 tasks across 144 real sites. Submission-interception prevents real-world side effects. Top: 33.3%. |
 | [GAIA](https://huggingface.co/gaia-benchmark) | General AI Assistant. Real-world tasks. |
 | [WebArena](https://github.com/web-arena-x/webarena) | Web agent benchmark. Real websites. |
 


### PR DESCRIPTION
## Section fit
Adds ClawBench under Observability and Evaluation > Benchmarks, alongside SWE-bench, AgentBench, GAIA, and WebArena. ClawBench is a browser-agent benchmark and fits the category directly.

## What ClawBench is
ClawBench evaluates AI browser agents on 153 everyday web tasks across 144 live production websites (15 life categories). 7 frontier models are evaluated; the best passes 33.3% of tasks. A Chrome-extension plus CDP submission-interception layer blocks only the final write request so agents can run end-to-end on real sites (Grubhub, Indeed, Amazon, United, etc.) without triggering real-world side effects.

## Public references
- Paper: https://arxiv.org/abs/2604.08523
- Repo: https://github.com/reacher-z/ClawBench
- Dataset: https://huggingface.co/datasets/NAIL-Group/ClawBench
- Site: https://claw-bench.com

## PR checklist
- [x] Entry is in alphabetical order within its section (placed between ARC-AGI-2 and GAIA)
- [x] Link is valid and points to official source
- [x] Description is concise and factual
- [x] Pricing info is current (not applicable — open research benchmark)
- [x] No promotional language

## Disclosure
I am affiliated with the ClawBench project.