### PR TITLE
Add skill-optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@
 | [ARC-AGI-2](https://arcprize.org) | ⭐ New frontier benchmark. Gemini 3.1 Pro leads. |
 | [GAIA](https://huggingface.co/gaia-benchmark) | General AI Assistant. Real-world tasks. |
 | [WebArena](https://github.com/web-arena-x/webarena) | Web agent benchmark. Real websites. |
+| [skill-optimizer](https://github.com/fastxyz/skill-optimizer) | CLI that benchmarks SKILL.md guidance docs against multiple LLMs, measures whether models call the right SDK/CLI/MCP tools with correct arguments, and runs an iterative optimizer to rewrite docs until every configured model meets a score floor. |
 
 ---
 


### PR DESCRIPTION
skill-optimizer is an open-source CLI tool that benchmarks and optimizes agent
guidance docs (SKILL.md) across multiple LLMs. It uses static action +
argument matching to measure whether each model calls the right tools, then
runs an iterative optimizer that rewrites docs until every configured model
meets a score floor. MIT licensed, CI-friendly.

Fits under the Benchmarks section alongside SWE-bench and AgentBench as a
developer-facing evaluation and optimization tool for agent guidance docs.

Disclosure: submitter is the author of skill-optimizer.

Repo: https://github.com/fastxyz/skill-optimizer