### PR TITLE
Add OpenTwins to Task and Workflow Agents › Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@
 | [Activepieces](https://github.com/activepieces/activepieces) | OSS Zapier alternative with AI. | Free (OSS) |
 | [Temporal](https://github.com/temporalio/temporal) | Durable execution for long-running agent workflows. | Free / Cloud |
 | [Mission Control](https://github.com/MeisnerDan/mission-control) | Cockpit for the agentic era — manage AI agent swarms with autonomous daemon, Field Ops for real-world execution, and approval workflows. | Free (OSS) |
+| [OpenTwins](https://github.com/Open-Twin/opentwins) | Autonomous digital-twin agents across 10 social platforms (Reddit, X, LinkedIn, Bluesky, Threads, Medium, Substack, Dev.to, PH, IH). Claude Code + Chrome CDP, local dashboard, MIT. | Free (OSS) |
 
 ### No-Code Agent Builders
 


### PR DESCRIPTION
## Adding OpenTwins

**Project:** [OpenTwins](https://github.com/Open-Twin/opentwins) — autonomous digital-twin agents across 10 social platforms.

**Section:** ⚡ Task and Workflow Agents → Automation

**Why it belongs:**
- Autonomous OSS automation tool for a very specific workflow (social-platform engagement as you)
- Powered by Claude Code with real Chrome automation via CDP
- Local-first: SQLite + Bree + web dashboard, no cloud
- MIT, actively maintained (see [releases](https://github.com/Open-Twin/opentwins/releases))

**Note on section choice:** there's no explicit Social/Marketing section. The Automation subsection already mixes workflow tools (n8n, Temporal) and specialized automation (Mission Control), so OpenTwins fits the profile. Happy to move under Browser and Desktop Agents › Developer Infrastructure if that reads better.

**Checklist:**
- [x] Row follows existing table format (Agent | Description | Pricing)
- [x] Link returns 200
- [x] No duplicate entry