### PR TITLE
Add AI Dev Jobs and Not Human Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@
 | [Julius AI](https://julius.ai) | Upload CSV/Excel, ask in natural language. | Free / Paid |
 | [Hex AI](https://hex.tech) | Collaborative data platform. AI analysis. | Free / Paid |
 | [PandasAI](https://github.com/Sinaptik-AI/pandas-ai) | Chat with your data. NL to Pandas/SQL. | Free (OSS) |
+| [AI Dev Jobs](https://aidevboard.com) | AI/ML job board + MCP server. 6,100+ jobs, 321 companies. REST API + MCP endpoint for agents. [GitHub](https://github.com/unitedideas/ai-dev-jobs). | Free |
 | [Signals CLI](https://github.com/sortlist/signals-cli) | Intent signal CLI. LinkedIn engagers, keyword posters, job changers, funding events. JSON output for agent pipelines. | Paid |
 | [TaskWeaver](https://github.com/microsoft/TaskWeaver) | Microsoft. Code-first data analytics agents. | Free (OSS) |
 | [AI for Database](https://aifordatabase.com) | Connect to any database in plain English. NL queries, self-refreshing dashboards, automated workflows triggered by data changes. | Freemium |
@@ -461,6 +462,8 @@
 | Tool | Description |
 |------|-------------|
 | [Agentify](https://github.com/koriyoshi2041/agentify) | CLI to transform OpenAPI specs into 9 agent formats (MCP, AGENTS.md, Claude tools, etc.). `npx agentify-cli`. |
+| [AI Dev Jobs MCP](https://aidevboard.com) | MCP server for AI/ML job data. 6,100+ jobs, 321 companies. Tools: `search_jobs`, `get_job`, `list_companies`, `get_stats`. `claude mcp add --transport http aidevjobs https://aidevboard.com/mcp`. [GitHub](https://github.com/unitedideas/ai-dev-jobs). |
+| [Not Human Search MCP](https://nothumansearch.ai) | Search engine for 1,750+ AI agent tools and MCP servers. Tools: `search`, `check_site`, `get_stats`, `verify_mcp`. Listed in official MCP registry. `claude mcp add --transport http nhs https://nothumansearch.ai/mcp`. [GitHub](https://github.com/unitedideas/nothumansearch). |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds **AI Dev Jobs** to the Data Analysis section — AI/ML job board with 6,100+ jobs, 321 companies, REST API + MCP server
- Adds **AI Dev Jobs MCP** and **Not Human Search MCP** to the Protocol Tooling section — both provide JSON-RPC MCP endpoints for agent integration

## Details

**AI Dev Jobs** (https://aidevboard.com) is an AI/ML job board with a REST API and MCP server. Agents can search jobs, get company data, and access statistics programmatically.

**Not Human Search** (https://nothumansearch.ai) is a search engine for 1,750+ AI agent tools and MCP servers. Its MCP server lets agents discover other agent-accessible tools, verify MCP endpoints, and check site agentic readiness.

Both are listed in the [official MCP server registry](https://github.com/modelcontextprotocol/servers):
- `com.aidevboard/jobs`
- `ai.nothumansearch/search`

Connect via:
```bash
claude mcp add --transport http aidevjobs https://aidevboard.com/mcp
claude mcp add --transport http nhs https://nothumansearch.ai/mcp
```

- AI Dev Jobs GitHub: https://github.com/unitedideas/ai-dev-jobs
- Not Human Search GitHub: https://github.com/unitedideas/nothumansearch