### PR TITLE
Add AgentsMesh to Multi-Agent Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@
 | [Microsoft Copilot](https://copilot.microsoft.com) | Office 365 integration. Enterprise. | Free / $30/user |
 | [Coze](https://coze.com) | ByteDance agent builder. Visual workflow. Plugin marketplace. | Free / Paid |
 | [Cursor AI Automated Team](https://github.com/joinwell52-AI/joinwell52) | 4-role AI team (PM+DEV+OPS+QA) in Cursor IDE. File-based task routing, auto patrol bot. 87 person-days in 17 days. | Free / OSS |
+| [AgentsMesh](https://agentsmesh.ai) | Self-hostable AI agent workforce. Remote AI workstations (AgentPods) with PTY sandbox + git worktree isolation. Multi-agent via channels + pod bindings. Built-in Kanban with MR/PR. Per-pod MCP server for Claude Code / Cursor. Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode. BYOK. | Free (OSS, BSL-1.1) |
 
 ---
 


### PR DESCRIPTION
## What
Adding [AgentsMesh](https://agentsmesh.ai) to the **🤖 Multi-Agent Platforms** section.

## Why it fits
AgentsMesh is a self-hostable AI Agent Workforce Platform with first-class multi-agent primitives: channels (Slack-style agent messaging), pod bindings (ticket-to-agent assignment), and per-pod MCP servers for tool-level coordination. It fits alongside TeamHero and the OSS entries in this section.

## Key features
- **AgentPods** — remote AI workstations with PTY sandbox + git worktree isolation
- **Multi-agent collaboration** via channels and pod bindings
- **Built-in Kanban** with ticket-pod binding and MR/PR integration
- **Per-pod MCP server** — Claude Code / Cursor can drive AgentsMesh
- **Self-hosted runners** — code never leaves your infrastructure
- **Enterprise-ready** — multi-tenant (Org > Team > User), SSO, RBAC, audit logs, air-gapped
- **BYOK** — bring your own API keys
- Multi-Git (GitHub / GitLab / Gitee)
- Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode, custom agents

## Project maturity
1.5k+ stars · v0.28.0 (2026-04-15) · Active CI · License: BSL-1.1 (transitions to GPL-2.0-or-later on 2030-02-28)

## Format
Matches the existing table format: \`| [name](url) | description | pricing |\`. Appended to the section's end.