### PR TITLE
Add Council Pilot — Autonomous expert-council-driven project builder for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 | [SWE-Agent](https://github.com/princeton-nlp/SWE-agent) | Princeton. Resolves real GitHub issues autonomously. | Free (OSS) |
 | [OpenHands](https://github.com/All-Hands-AI/OpenHands) | OSS autonomous software engineer (ex-OpenDevin). | Free (OSS) |
 | [Grok Build (xAI)](https://x.ai) | 8 parallel agents for code gen. Multi-agent "Society of Mind" architecture. | xAI sub |
+| [Council Pilot](https://github.com/wd041216-bit/council-pilot) | Claude Code skill. Builds expert councils from public sources, autonomously drives projects through build-score-debug loops until 100/100 maturity. | Free (OSS) |
 
 ### Code Review and Security
 


### PR DESCRIPTION
## Addition

**Council Pilot** — Autonomous Software Engineers section

### Description

Council Pilot is a Claude Code skill that builds an expert council from public sources, then autonomously drives your project through build-score-debug loops until it reaches 100/100 maturity.

Key features:
- **Autonomous long-running work**: One sentence triggers 2-3+ hours of focused, self-directed work
- **Adversarial expert scoring**: Expert lenses distilled from real public sources with source-gating tiers (A/B/C). The council debates every scoring decision
- **Domain-flexible**: The expert knowledge base is built from scratch per domain via web search
- **10-phase pipeline**: INIT → DISCOVER → DISTILL → COUNCIL → SCORE → BUILD → DEBUG → RESCORE → GAP_FILL → SUBMIT

### Checklist

- [x] Entry is in the correct section (Autonomous Software Engineers)
- [x] Link is valid and points to official source
- [x] Description is concise and factual
- [x] No promotional language
- [x] OSS, MIT licensed

🤖 Generated with [Claude Code](https://claude.com/claude-code)