### PR TITLE
Add Not Human Search to Protocol Tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@
 | Tool | Description |
 |------|-------------|
 | [Agentify](https://github.com/koriyoshi2041/agentify) | CLI to transform OpenAPI specs into 9 agent formats (MCP, AGENTS.md, Claude tools, etc.). `npx agentify-cli`. |
+| [Not Human Search](https://nothumansearch.ai) | Search engine for the agentic web. Indexes 2,000+ sites ranked 0–100 on agentic readiness (llms.txt, OpenAPI, MCP, ai-plugin.json). Itself an MCP server with `verify_mcp` tool for live JSON-RPC validation. Install: `curl -fsSL https://nothumansearch.ai/install \| sh`. |
 
 ---
 


### PR DESCRIPTION
Adds [Not Human Search](https://nothumansearch.ai) to Protocols and Standards → Protocol Tooling, alongside Agentify.

Not Human Search is a search engine for the agentic web:
- Indexes 2,000+ sites ranked 0–100 on agentic readiness (llms.txt, OpenAPI, MCP, ai-plugin.json, structured API, robots.txt AI rules, Schema.org)
- Itself an MCP server with 8 tools including `verify_mcp` — live JSON-RPC validation of any advertised MCP endpoint
- One-line install: `curl -fsSL https://nothumansearch.ai/install | sh` (wires into Claude Code automatically; prints Cursor/Cline/Continue snippets otherwise)
- Free, no auth, open data

Relevant to 2026 ecosystem data: of 5,578 sites we probed claiming MCP support, only 10.3% (575) actually answer `tools/list`. NHS is the discovery + verification layer on top of that.