### PR TITLE
Add Burnd to Observability and Evaluation / Tracing and Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@
 | [Helicone](https://github.com/Helicone/helicone) | OSS LLM observability. One-line integration. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback when your AI agent config breaks it. Zero deps, single Python file. Probes health endpoint, reverts config on failure. |
 | [Weights and Biases Weave](https://wandb.ai/site/weave) | Trace and evaluate LLM apps. |
+| [Burnd](https://github.com/garvitsurana/burnd) | Local-first CLI. Parses Claude Code JSONL sessions, runs cost-leak detectors (retry storms, tool overuse, repeated reads, thrash) and prints savings estimates. MIT, npx, zero telemetry. |
 
 ### Benchmarks
 


### PR DESCRIPTION
Adds Burnd under Observability and Evaluation → Tracing and Monitoring.

Why it fits this list specifically: the section covers tools that let agent builders see inside their workloads (Langfuse, Phoenix, Helicone, Weave). Those are provider-agnostic SaaS/self-hosted platforms. Burnd is the local-first, terminal-only complement for the Claude Code agent workflow — it reads the JSONL sessions the CLI already writes and runs leak detectors (retry storms, tool overuse, repeated reads, thrash, tired-coding) so agent builders can catch expensive patterns without instrumenting anything.

Meets CONTRIBUTING: publicly available, actively maintained, open source.

- Repo: https://github.com/garvitsurana/burnd
- npm: getburnd
- Site: https://getburnd.vercel.app
- MIT.