### PR TITLE
Add LemonCake to AI Safety and Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@
 | [Rebuff](https://github.com/protectai/rebuff) | Prompt injection detection. |
 | [Lakera Guard](https://lakera.ai) | Real-time protection. Prompt injection, data leakage, toxicity. |
 | [OWASP Top 10 for Agentic Apps](https://owasp.org) | ⭐ **2026 Framework** Goal hijacking, tool misuse, cascading failure mitigations. |
-| [LemonCake](https://lemoncake.xyz) | Pay Tokens for AI agents. JWT-signed upstream-API proxy with hard USDC spending caps, domain scope, and a sub-second kill-switch. Every charge auto-journaled to freee / Money Forward / QuickBooks. |
+| [LemonCake](https://lemoncake.xyz?utm_source=awesome-2026&utm_medium=github) | Pay Tokens for AI agents. JWT-signed upstream-API proxy with hard USDC spending caps, domain scope, and a sub-second kill-switch. Every charge auto-journaled to freee / Money Forward / QuickBooks. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -524,6 +524,7 @@
 | [Rebuff](https://github.com/protectai/rebuff) | Prompt injection detection. |
 | [Lakera Guard](https://lakera.ai) | Real-time protection. Prompt injection, data leakage, toxicity. |
 | [OWASP Top 10 for Agentic Apps](https://owasp.org) | ⭐ **2026 Framework** Goal hijacking, tool misuse, cascading failure mitigations. |
+| [LemonCake](https://lemoncake.xyz) | Pay Tokens for AI agents. JWT-signed upstream-API proxy with hard USDC spending caps, domain scope, and a sub-second kill-switch. Every charge auto-journaled to freee / Money Forward / QuickBooks. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@
 | [Rebuff](https://github.com/protectai/rebuff) | Prompt injection detection. |
 | [Lakera Guard](https://lakera.ai) | Real-time protection. Prompt injection, data leakage, toxicity. |
 | [OWASP Top 10 for Agentic Apps](https://owasp.org) | ⭐ **2026 Framework** Goal hijacking, tool misuse, cascading failure mitigations. |
-| [LemonCake](https://lemoncake.xyz?utm_source=awesome-2026&utm_medium=github) | Pay Tokens for AI agents. JWT-signed upstream-API proxy with hard USDC spending caps, domain scope, and a sub-second kill-switch. Every charge auto-journaled to freee / Money Forward / QuickBooks. |
+| [LemonCake](https://github.com/evidai/lemon-cake) | Pay Tokens for AI agents. JWT-signed upstream-API proxy with hard USDC spending caps, domain scope, and a sub-second kill-switch. Every charge auto-journaled to freee / Money Forward / QuickBooks. MIT-licensed SDKs for MCP, Eliza, and Dify. |
 
 ---
 


### PR DESCRIPTION
Adds [LemonCake](https://lemoncake.xyz) to the **🛡 AI Safety and Guardrails** section.

LemonCake sits alongside Guardrails AI / NeMo Guardrails / LLM Guard as a **runtime financial guardrail**:

- Hard USDC spending caps enforced at JWT signature-verification time (agents literally cannot exceed budget)
- Sub-second kill-switch that revokes all live tokens when anomalies are detected
- Domain-scoped Pay Tokens so a token for `api.openai.com/*` cannot be repurposed
- Every settled call auto-journaled to freee / Money Forward / QuickBooks for audit

Addresses the **runaway-agent** failure mode that OWASP Top 10 for Agentic Apps (already on this list) calls out under "tool misuse" and "cascading failure". Complementary to content-guardrails like Guardrails AI and NeMo.

Thanks for the excellent 2026 list!