### PR TITLE
Add Ferro Labs AI Gateway entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,12 @@
 | [Anything LLM](https://github.com/Mintplex-Labs/anything-llm) | All-in-one AI app. RAG, agents. Desktop + Docker. |
 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | Data interaction with local LLM. 100% private. |
 
+### Gateways and Routers
+
+| Tool | Description |
+|------|-------------|
+| [Ferro Labs AI Gateway](https://github.com/ferro-labs/ai-gateway) | Self-hosted Go AI gateway/router. Routes 29 providers through one OpenAI-compatible API. Guardrails, MCP support, dashboard, single-binary deploy. |
+
 ---
 
 ## 🤖 Multi-Agent Platforms


### PR DESCRIPTION
Adds **[Ferro Labs AI Gateway](https://github.com/ferro-labs/ai-gateway)** to the awesome list.

Changes

 - audited the project at ferro-labs/ai-gateway
 - added it under 🏠 Local and Self-Hosted AI
 - created a dedicated Gateways and Routers subsection for accurate categorization
 - added a concise description covering:
  - self-hosted Go gateway/router
  - OpenAI-compatible API
  - 29-provider routing
  - guardrails, MCP support, dashboard, and single-binary deploy

Why this section

ai-gateway is not an agent UI or framework; it is self-hosted infrastructure for routing and managing LLM traffic, so a gateway/router subsection is the most accurate fit.