### PR TITLE
Add AceTagGen to Music and Audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@
 | [ElevenLabs Music](https://elevenlabs.io) | Vocals, instrumentals. Sectional editing. Stem separation. | Plan included |
 | [Stable Audio](https://stableaudio.com) | High-quality. Commercial license. | Free / Paid |
 | [Meta AudioCraft](https://github.com/facebookresearch/audiocraft) | OSS. MusicGen + AudioGen. | Free (OSS) |
+| [AceTagGen](https://acetaggen.com) | Structured prompt builder for Suno AI. 12-step tag picker + quality scorer, fits Suno's 200-char Style limit. | Free / $9.99+/mo |
 
 ### 3D and Design
 


### PR DESCRIPTION
Adding AceTagGen to the Music and Audio table.

It's a structured prompt builder specifically for Suno AI — a 12-step tag picker that enforces Suno's 200-character Style field limit and runs a quality scorer over the result before you generate. Freemium (free core, Premium $9.99/mo or $69/yr).

Disclosure: I built it.