### PR TITLE
Add The AI Agent Index to Newsletters and Communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,6 +617,7 @@
 | [r/LangChain](https://reddit.com/r/LangChain) | Agent developer community |
 | [r/ClaudeAI](https://reddit.com/r/ClaudeAI) | Claude community |
 | [r/LocalLLaMA](https://reddit.com/r/LocalLLaMA) | Self-hosted LLM community |
+| [The AI Agent Index](https://theaiagentindex.com) | Structured directory of 260+ AI agents with public API, editorial ratings, and JSON-LD schema |
 
 ---
 


### PR DESCRIPTION
The AI Agent Index is a dataset-first, machine-readable directory of AI agents for business automation. Covers sales, support, research, marketing, coding, and HR categories. Includes a public JSON API, editorial ratings, and full Schema.org markup.