### PR TITLE
Add Caesar to Deep Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@
 | [DeerFlow](https://github.com/bytedance/deer-flow) | ByteDance OSS. Planning, tools, memory, execution. | Free (OSS) |
 | [GPT Researcher](https://github.com/assafelovic/gpt-researcher) | OSS autonomous comprehensive research. | Free (OSS) |
 | [STORM](https://github.com/stanford-oval/storm) | Stanford. Writes Wikipedia-like articles from scratch. | Free (OSS) |
+| [Caesar](https://github.com/jasonzliang/caesar-agent) | Cognizant AI Lab OSS. Graph-based exploration + adversarial synthesis. Outperforms ChatGPT / Gemini Deep Research on creative reasoning ([paper](https://doi.org/10.13140/RG.2.2.15118.22088), p<0.001). | Free (OSS) |
 
 ### Data Analysis
 


### PR DESCRIPTION
Adding [Caesar](https://github.com/jasonzliang/caesar-agent) to the Deep Research table, appended after STORM so the open-source entries stay grouped together.

Caesar builds a knowledge graph during web exploration (instead of flat retrieval), then refines its answer through an adversarial Generator-Verifier synthesis loop. The loop produces multiple drafts, then generates orthogonal queries that target weaknesses in each draft before a generative merge. This is designed to produce the kind of non-derivative output that standard single-pass deep research tools have trouble with on creative or cross-disciplinary questions.

Approach is from a paper we published in March ([Liang, Meyerson, Miikkulainen 2026](https://doi.org/10.13140/RG.2.2.15118.22088), Cognizant AI Lab). In a blinded 3-judge LLM-as-a-Judge creativity evaluation, Caesar outscored every Deep Research product already in this section: 25.29 / 30 vs. Gemini 3 Deep Research 22.27, Sonnet 4.5 Deep Research 20.89, and ChatGPT / GPT-5.2 Deep Research 15.40 (p<0.001 across all conditions).

v0.3.0 released April 19, Python 3.10+, MIT licensed. Happy to trim or reorder if you'd prefer.