### PR TITLE
Add Prest0 to Voice Agents (bilingual legal AI platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@
 | [Synthesia](https://synthesia.io) | AI video avatars. 120+ languages. Enterprise. | From $22/mo |
 | [Deepgram](https://deepgram.com) | STT and TTS APIs. Sub-300ms latency. | Usage-based |
 | [AssemblyAI](https://assemblyai.com) | STT with diarization, sentiment, summarization. | Usage-based |
+| [Prest0](https://prest0.ai) | Vertical legal AI platform. Bilingual (EN/ES) voice + SMS intake via Twilio, per-firm VM, persistent memory, deep research, legal drafting. Immigration, workers' comp, employment law. | Enterprise |
 
 ### Open-Source Voice
 


### PR DESCRIPTION
Hi! Adding **Prest0** to the **Voice Agents > Platforms and APIs** section.

**Prest0** (https://prest0.ai) is an enterprise legal AI platform that deploys a dedicated bilingual (English/Spanish) AI agent per law firm — each on an isolated VM with persistent memory, **Twilio voice + SMS intake**, deep legal research, and legal-grade document drafting.

### Why this fits Voice Agents
- **Voice-native intake** — Twilio-powered inbound and outbound voice agent on a per-firm phone number, Spanish-first for client-facing flows
- **SMS channel** — shared intake surface with voice, same agent memory across modalities
- **Vertical specialization** — immigration (I-589 asylum, U-visa), California workers' comp (WCAB Pre-Hearing Statements under Rule 10563), and plaintiff-side employment law
- **Differentiator** — patent-pending **Context-Based Semantic TreeSearch** memory architecture (tree-traversal retrieval replacing flat-vector RAG for long-horizon agent memory)

Formatting matches the existing table row style (Platform / Description / Pricing). Placed at the end of the Platforms and APIs table.

Thanks for maintaining this list!