### PR TITLE
Add Voidly MCP Server to Deep Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@
 | [DeerFlow](https://github.com/bytedance/deer-flow) | ByteDance OSS. Planning, tools, memory, execution. | Free (OSS) |
 | [GPT Researcher](https://github.com/assafelovic/gpt-researcher) | OSS autonomous comprehensive research. | Free (OSS) |
 | [STORM](https://github.com/stanford-oval/storm) | Stanford. Writes Wikipedia-like articles from scratch. | Free (OSS) |
+| [Voidly MCP Server](https://github.com/voidly-ai/mcp-server) | 116 MCP tools. Global censorship intel (19.6M samples, 5K+ incidents), E2E agent messaging, agent payments. | Free (OSS) |
 
 ### Data Analysis
 


### PR DESCRIPTION
## Summary
- Adds [Voidly MCP Server](https://github.com/voidly-ai/mcp-server) to the Data and Research Agents > Deep Research section
- 116 MCP tools exposing global internet censorship intelligence (19.6M live samples, 5,356 citable incidents, 10-year OONI archive)
- Includes tools for E2E encrypted agent-to-agent messaging and agent payments
- Published on npm: `@voidly/mcp-server` (post-v2.16.0). Works with Claude Desktop, Cursor, Windsurf, and any MCP-compatible client

## Why Deep Research
The server's primary value is programmatic access to censorship research data at global scale (countries, ISPs, domains, incidents with citations). This matches the Deep Research category's focus on agents that do factual investigation with citations.

## Checklist
- [x] Entry follows existing table format (Agent | Description | Pricing)
- [x] Added alphabetically at end of Deep Research table
- [x] Link is valid and points to official source
- [x] Description is concise and factual
- [x] No promotional language