### PR TITLE
Add AP2, x402, and MPP to Protocols and Standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,9 @@
 | [Tool Use (Anthropic)](https://docs.anthropic.com/en/docs/build-with-claude/tool-use) | Claude native tool-use. Structured JSON. |
 | [OpenAPI](https://github.com/OAI/OpenAPI-Specification) | Industry-standard API spec. Foundation for agent tools. |
 | [HCS (Hashgraph Consensus Service)](https://hol.org) | Hedera open standards for agent identity (HCS-14 UAIDs), trustless P2P communication (HCS-10), and cross-protocol bridging. 187K+ verified agents. |
+| [AP2 (Agentic Payments Protocol)](https://github.com/google-agentic-commerce/AP2) | Google open standard for agent-initiated commerce. Signed mandate chain (Intent → Cart → Payment) for AI agent purchases. Reference impl: [AlgoVoi](https://api1.ilovechicken.co.uk/.well-known/agent.json). |
+| [x402 (HTTP 402 Payment Required)](https://github.com/coinbase/x402) | Coinbase open protocol for HTTP-native crypto micropayments. AI agents pay per-request via `X-PAYMENT` header. Mechanisms span EVM, AVM, SVM, Stellar, Aptos. |
+| [MPP (Machine Payments Protocol)](https://github.com/tempoxyz/mpp) | IETF-track open standard for machine-to-machine payments. Agent-readable service directory with payment defaults + endpoint metadata. Stripe/Tempo-backed. |
 
 ### Protocol Tooling
 


### PR DESCRIPTION
Adds three protocol entries that the current Protocols and Standards table is missing - all relevant to AI-agent commerce, none currently listed:

| Protocol | What it is |
|----------|------------|
| **AP2** (Agentic Payments Protocol) | Google open standard for agent-initiated purchases. Signed mandate chain: IntentMandate -> CartMandate -> PaymentMandate. |
| **x402** (HTTP 402 Payment Required) | Coinbase protocol for HTTP-native crypto micropayments. Agents pay per-request via the \`X-PAYMENT\` header. Mechanisms span EVM, AVM, SVM, Stellar, Aptos. |
| **MPP** (Machine Payments Protocol) | IETF-track standard for machine-to-machine payments. Agent-readable service directory with payment defaults + endpoint metadata. Stripe/Tempo-backed. |

All three are foundational to the "agent economy" thesis this list already highlights (MCP, A2A, etc). They're widely discussed in industry but absent from the current table.

---

*AlgoVoi (chopmob-cloud) - chopmob@gmail.com - Acquisition enquiries: https://docs.algovoi.co.uk/acquisition*