### PR TITLE
Add EnigmAgent — encrypted credential vault for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,7 @@
 | [Rebuff](https://github.com/protectai/rebuff) | Prompt injection detection. |
 | [Lakera Guard](https://lakera.ai) | Real-time protection. Prompt injection, data leakage, toxicity. |
 | [OWASP Top 10 for Agentic Apps](https://owasp.org) | ⭐ **2026 Framework** Goal hijacking, tool misuse, cascading failure mitigations. |
+| [EnigmAgent](https://github.com/Agnuxo1/EnigmAgent) | Browser extension + MCP server that gives AI agents access to encrypted credentials via `{{PLACEHOLDER}}` syntax. Secrets never exposed to the LLM. AES-256-GCM + Argon2id, zero cloud. |
 
 ---
 


### PR DESCRIPTION
## What's being added

**EnigmAgent** belongs in the AI Safety and Guardrails section because it solves a real security gap: AI agents routinely receive prompts containing raw API keys and credentials, which exposes them in LLM context windows, logs, and completions.

### What EnigmAgent does
- Browser extension + MCP server that stores credentials in an AES-256-GCM + Argon2id encrypted local vault
- AI agents use `{{PLACEHOLDER}}` syntax — real values are resolved at runtime, never sent to the LLM
- Zero cloud, zero telemetry, MIT licensed
- Works with Claude, GPT-4, Cursor, LangChain, CrewAI, AutoGen, and any MCP-compatible agent

**GitHub:** https://github.com/Agnuxo1/EnigmAgent
**npm:** `enigmagent-mcp`
