### PR TITLE
Add AnveVoice - Voice AI agent for websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@
 | [Synthesia](https://synthesia.io) | AI video avatars. 120+ languages. Enterprise. | From $22/mo |
 | [Deepgram](https://deepgram.com) | STT and TTS APIs. Sub-300ms latency. | Usage-based |
 | [AssemblyAI](https://assemblyai.com) | STT with diarization, sentiment, summarization. | Usage-based |
+| [AnveVoice](https://anvevoice.app) | Voice AI agent for websites with agentic DOM actions — navigates pages, fills forms, clicks buttons autonomously. 50+ languages, <700ms latency, one-line embed. MCP support. | Free tier / Paid |
 
 ### Open-Source Voice
 


### PR DESCRIPTION
Adds AnveVoice to the Voice Agents / Platforms and APIs section. Voice AI platform with autonomous DOM actions, MCP support, 50+ languages. Free tier available.