### PR TITLE
Add BuyWhere — real-time Singapore product catalog API for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@
 | [Hex AI](https://hex.tech) | Collaborative data platform. AI analysis. | Free / Paid |
 | [PandasAI](https://github.com/Sinaptik-AI/pandas-ai) | Chat with your data. NL to Pandas/SQL. | Free (OSS) |
 | [Signals CLI](https://github.com/sortlist/signals-cli) | Intent signal CLI. LinkedIn engagers, keyword posters, job changers, funding events. JSON output for agent pipelines. | Paid |
+| [BuyWhere](https://buywhere.ai) | Real-time Singapore product catalog API for AI agents. Live pricing from Harvey Norman, Shopee, and Lazada. 1,000+ products, MCP-native, one API call. | Free / Paid |
 | [TaskWeaver](https://github.com/microsoft/TaskWeaver) | Microsoft. Code-first data analytics agents. | Free (OSS) |
 | [AI for Database](https://aifordatabase.com) | Connect to any database in plain English. NL queries, self-refreshing dashboards, automated workflows triggered by data changes. | Freemium |
 

--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@
 | [Instantly](https://instantly.ai) | AI cold email. Unlimited accounts. Smart rotation. | From $30/mo |
 | [Overloop CLI](https://github.com/sortlist/overloop-cli) | AI outbound CLI. Source 450M+ contacts, email + LinkedIn campaigns, conversations. Agent-native JSON output. | $69-99/mo |
 | [Lavender](https://lavender.ai) | AI email coach. Real-time scoring. | Free / $29/mo |
+| [BuyWhere](https://buywhere.ai) | AI-powered cross-border shopping discovery agent for AI agents. Searches 11M+ live products across Shopee, Lazada, Amazon, Harvey Norman, and 200+ retailers in SG/SEA/US with price comparison and deal alerts. MCP-native (`npx @buywhere/mcp-server`) and REST API. | Free / Pay-per-call API |
 
 ---
 


### PR DESCRIPTION
BuyWhere is a real-time product catalog API built specifically for AI agents. It gives agents access to live pricing across Harvey Norman, Shopee, and Lazada in Singapore with a single API call.

- 1,000+ products updated daily
- MCP-native (works with Claude agents)
- REST API for LangChain, CrewAI, LlamaIndex, and any agent framework
- No scraping — live data

Fits naturally in the Data Analysis section as an e-commerce/product data source for agents.

Docs: https://buywhere.ai/developers