### PR TITLE
feat: add KubeStellar Console to Self-Hosted Agents and UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@
 | [LibreChat](https://github.com/danny-avila/LibreChat) | Self-hosted multi-model chat. All major providers. |
 | [LobeChat](https://github.com/lobehub/lobe-chat) | OSS ChatGPT/Gemini UI. Plugin system. Multi-modal. |
 | [KinBot](https://github.com/MarlBurroW/kinbot) | Self-hosted AI agent platform. Persistent memory (hybrid search + LLM re-ranking), 23+ providers (including Ollama), plugin store, mini-apps SDK, cron scheduling, 6 messaging channels. SQLite, runs on a Pi. |
+| [KubeStellar Console](https://github.com/kubestellar/console) | Self-hosted multi-cluster Kubernetes dashboard with AI agent (kc-agent). MCP server bridges Claude, Copilot, Cursor to kubeconfig clusters. 150+ observability cards, real-time diagnostics. CNCF project. |
 | [Anything LLM](https://github.com/Mintplex-Labs/anything-llm) | All-in-one AI app. RAG, agents. Desktop + Docker. |
 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | Data interaction with local LLM. 100% private. |
 


### PR DESCRIPTION
Add [KubeStellar Console](https://github.com/kubestellar/console) to the Self-Hosted Agents and UIs section.

**What it is:**
Self-hosted multi-cluster Kubernetes dashboard with an AI agent (kc-agent) that implements MCP (Model Context Protocol) to bridge AI tools like Claude, Copilot, and Cursor to kubeconfig clusters.

**Key features:**
- 150+ observability cards (pods, deployments, services, RBAC, networking, storage)
- Real-time diagnostics and cross-cluster resource management
- MCP server bridges LLM tools to Kubernetes clusters
- SQLite WASM persistent cache, 15+ themes, 10 locales
- Part of the [CNCF KubeStellar](https://kubestellar.io) project

**Links:**
- Repository: https://github.com/kubestellar/console
- Live demo: https://console.kubestellar.io
- Helm chart for self-hosting included