### PR TITLE
Add prompt-to-asset to Image Generation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@
 | [Leonardo AI](https://leonardo.ai) | Multi-model. Realtime Canvas. 3D gaming assets. Canva-owned. | Free / $12+/mo |
 | [Recraft](https://recraft.ai) | Design-focused. Vector art, brand consistency. | Free / Paid |
 | [InkOS](https://github.com/Narcooo/inkos) | Autonomous novel-writing CLI agent. Agents collaborate to produce long-form fiction with continuity auditing, anti-AI-slop filtering, and style cloning. | Free / OSS |
+| [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) | MCP server routing image generation prompts across 30+ models (DALL-E, Flux, Stable Diffusion, Midjourney, and more) via a unified API. `npm install -g prompt-to-asset`. | Free (OSS) |
 
 ### Video Generation
 


### PR DESCRIPTION
## Add prompt-to-asset to Image Generation section

### What is this tool?

[prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) is an MCP (Model Context Protocol) server that routes image generation prompts across 30+ models — DALL-E, Flux, Stable Diffusion, Midjourney, and more — through a unified API. Install with `npm install -g prompt-to-asset`.

### Why it belongs here

- **2025-2026 tool**: actively maintained npm package
- **Publicly available**: open-source, installable today
- **Developer-facing**: fits the Image Generation section alongside other tools that integrate with AI image models
- The existing InkOS entry shows CLI/developer tools are welcome here

### Checklist

- [x] Tool is publicly available and actively maintained
- [x] Entry added after InkOS (other developer/OSS tool in the section)
- [x] Link is valid
- [x] Pricing field filled (`Free (OSS)`)
- [x] No duplicate entry