### PR TITLE
Add OpenHermit (Self-Hosted Agents and UIs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@
 | [LibreChat](https://github.com/danny-avila/LibreChat) | Self-hosted multi-model chat. All major providers. |
 | [LobeChat](https://github.com/lobehub/lobe-chat) | OSS ChatGPT/Gemini UI. Plugin system. Multi-modal. |
 | [KinBot](https://github.com/MarlBurroW/kinbot) | Self-hosted AI agent platform. Persistent memory (hybrid search + LLM re-ranking), 23+ providers (including Ollama), plugin store, mini-apps SDK, cron scheduling, 6 messaging channels. SQLite, runs on a Pi. |
+| [OpenHermit](https://github.com/williamwa/openhermit) | Open-source platform for deploying AI agents as production services. Internal state (memory, sessions, skills, MCP, schedules, secrets) in Postgres; per-agent Docker workspaces. Fleet ops: install/enable across all agents with one command. CLI, Web UI, Telegram/Discord/Slack. MIT, TypeScript. |
 | [Anything LLM](https://github.com/Mintplex-Labs/anything-llm) | All-in-one AI app. RAG, agents. Desktop + Docker. |
 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | Data interaction with local LLM. 100% private. |
 


### PR DESCRIPTION
Adds [OpenHermit](https://github.com/williamwa/openhermit) under **Local and Self-Hosted AI → Self-Hosted Agents and UIs**.

OpenHermit is an open-source platform for deploying AI agents as production services. The differentiator: instead of scattering agent state across files and per-agent SQLite DBs (the typical CLI-agent stack), OpenHermit puts all internal state — memory, sessions, skills, MCP, schedules, secrets — in Postgres, while only the workspace stays as files in a per-agent Docker container. That makes fleet operations (installing a skill across all agents, pushing an instruction, rotating a secret) a single command instead of a deploy script.

- License: MIT
- Stack: TypeScript, Postgres, Docker
- Channels: CLI, Web UI, Telegram, Discord, Slack
- Repo: https://github.com/williamwa/openhermit
- Site / write-up: https://openhermit.ai/blog/agents-but-operable

Happy to adjust placement/wording — thanks for maintaining this list!