### PR TITLE
Add Puppyone to Self-Hosted Agents and UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@
 | [KinBot](https://github.com/MarlBurroW/kinbot) | Self-hosted AI agent platform. Persistent memory (hybrid search + LLM re-ranking), 23+ providers (including Ollama), plugin store, mini-apps SDK, cron scheduling, 6 messaging channels. SQLite, runs on a Pi. |
 | [Anything LLM](https://github.com/Mintplex-Labs/anything-llm) | All-in-one AI app. RAG, agents. Desktop + Docker. |
 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | Data interaction with local LLM. 100% private. |
+| [Puppyone](https://github.com/puppyone-ai/puppyone) | Self-hosted file system for AI agents. Auto-versioning on every write, per-agent ACLs (File Level Security), audit logs, 15+ data connectors (Notion/GitHub/Drive/Linear). Native MCP + REST + CLI + sandbox. Supabase + FastAPI + Docker Compose. Apache 2.0. |
 
 ---
 


### PR DESCRIPTION
## What this adds

Adds [Puppyone](https://github.com/puppyone-ai/puppyone) to the **Self-Hosted Agents and UIs** section.

## What it is

Puppyone is a self-hosted file system designed for AI agents. It complements existing entries in this section like OpenClaw (agent runtime), Open WebUI (chat UI), and Anything LLM (RAG app) by providing the **storage layer** they share — versioned, ACL-protected files that any local agent can read/write.

Key properties:

- **Auto-versioning on every write** — agent edits are snapshotted automatically, no manual \`git commit\`
- **File-Level Security (FLS)** — per-agent access control enforced at the storage layer (RLS-equivalent for files)
- **15+ data connectors** — Notion, GitHub, Drive, Linear, etc. sync external sources as agent-readable files
- **Multi-channel access** — same files exposed via MCP / REST / CLI / sandbox simultaneously

Stack: Supabase (Postgres + Auth) + FastAPI + Next.js + Docker Compose. Apache 2.0.

## Why it fits this section

Aligns with the section's pattern (OpenClaw, KinBot, Anything LLM, etc.): self-hostable via \`docker compose up -d\`, runs entirely on user infrastructure, no SaaS dependency.

- Repo: https://github.com/puppyone-ai/puppyone
- Site: https://www.puppyone.ai
- License: Apache 2.0

Made with [Cursor](https://cursor.com)