### PR TITLE
Add KinthAI to Multi-Agent Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@
 | [Grok](https://x.ai) | Real-time X data. Grok 4.20. Multi-agent Society of Mind. Image gen. | X Premium+ |
 | [Meta AI](https://meta.ai) | Llama-powered. WhatsApp/Messenger. Manus acquisition. | Free |
 | [TeamHero](https://github.com/sagiyaacoby/TeamHero) | Open-source multi-agent orchestration with web dashboard, task lifecycle, knowledge base, and autopilot mode. Built on Claude Code. Runs locally. | Free (OSS) |
+| [KinthAI](https://agents.kinthai.ai) | OpenClaw-based multi-agent platform. Persistent per-user memory, 221-agent group chat tested, agent marketplace, character card import. | Free / $24.90/mo |
 | [Microsoft Copilot](https://copilot.microsoft.com) | Office 365 integration. Enterprise. | Free / $30/user |
 | [Coze](https://coze.com) | ByteDance agent builder. Visual workflow. Plugin marketplace. | Free / Paid |
 | [Cursor AI Automated Team](https://github.com/joinwell52-AI/joinwell52) | 4-role AI team (PM+DEV+OPS+QA) in Cursor IDE. File-based task routing, auto patrol bot. 87 person-days in 17 days. | Free / OSS |


### PR DESCRIPTION
## KinthAI — OpenClaw-Based Multi-Agent Platform

[KinthAI](https://agents.kinthai.ai) is a multi-tenant platform built on OpenClaw, focused on persistent memory and multi-agent collaboration.

**Features:**
- Persistent per-user memory (not sliding window — agents genuinely remember across sessions)
- Multi-agent group chat (stress-tested at 221 agents)
- Agent marketplace with revenue sharing
- Character card import (Character.AI / SillyTavern compatible)
- Token budget management
- Free tier + $24.90/mo paid

**Technical writeups:**
- [221 Agents in One Chat](https://blog.kinthai.ai/221-agents-multi-agent-coordination-lessons)
- [Persistent Memory Architecture](https://blog.kinthai.ai/why-character-ai-forgets-you-persistent-memory-architecture)
- [Multi-Tenancy at Scale](https://blog.kinthai.ai/openclaw-multi-tenancy-why-vm-per-user-doesnt-scale)