### PR TITLE
Add NicheData KDP Intelligence API

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@
 | [Signals CLI](https://github.com/sortlist/signals-cli) | Intent signal CLI. LinkedIn engagers, keyword posters, job changers, funding events. JSON output for agent pipelines. | Paid |
 | [TaskWeaver](https://github.com/microsoft/TaskWeaver) | Microsoft. Code-first data analytics agents. | Free (OSS) |
 | [AI for Database](https://aifordatabase.com) | Connect to any database in plain English. NL queries, self-refreshing dashboards, automated workflows triggered by data changes. | Freemium |
+| [NicheData KDP Intelligence](https://nichedata.dev) | Niche research API for AI agents. KDP keyword demand, competition, BSR ranges, revenue estimates. x402 micropayments (USDC on Base). | $0.03/query |
 
 ### RAG and Knowledge Bases
 


### PR DESCRIPTION
## Add NicheData KDP Intelligence API

Adds [NicheData KDP Intelligence](https://nichedata.dev) to the **Data Analysis** section.

### What it is
A niche research data API designed for AI agents. Provides Kindle Direct Publishing keyword intelligence:
- Demand scores and competition intensity
- BSR (Best Sellers Rank) ranges
- Revenue estimates and pricing analytics

### Why it fits this list
- **Agent-native**: Built for autonomous AI agent consumption via x402 micropayments — no API keys or subscriptions needed
- **Pay-per-query**: $0.03 USDC per call on Base L2
- **Discovery endpoint**: Free `GET /v1/niches` for agents to browse available keywords
- **OpenAPI 3.1.0**: Machine-readable spec at `/openapi.json`

### Links
- API: https://nichedata.dev
- Docs: https://nichedata.dev/docs
- OpenAPI: https://nichedata.dev/openapi.json