### PR TITLE
Add Aeon to Self-Hosted Agents and UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@
 | [Open WebUI](https://github.com/open-webui/open-webui) | Self-hosted ChatGPT UI. Access control. Extensions. |
 | [OpenClaw](https://github.com/openclaw/openclaw) | Fastest-growing GitHub repo ever (9k to 188k stars in 60 days). Self-hosted agent across WhatsApp, Telegram, Slack, Discord, Signal. 5,700+ community skills. | 
 | [openclaw-starter](https://github.com/feralghost/openclaw-starter) | Fork-and-run template for 24/7 autonomous AI agents. Pre-configured SOUL.md, memory system, KANBAN, heartbeat. Start in 30 minutes. |
+| [Aeon](https://github.com/aaronjmars/aeon) | Autonomous agent framework that runs unattended on GitHub Actions (zero infra). 90+ skills (research, dev, crypto, productivity), self-healing with quality scoring, persistent memory, reactive triggers, MCP + A2A integrations. MIT. |
 | [LibreChat](https://github.com/danny-avila/LibreChat) | Self-hosted multi-model chat. All major providers. |
 | [LobeChat](https://github.com/lobehub/lobe-chat) | OSS ChatGPT/Gemini UI. Plugin system. Multi-modal. |
 | [KinBot](https://github.com/MarlBurroW/kinbot) | Self-hosted AI agent platform. Persistent memory (hybrid search + LLM re-ranking), 23+ providers (including Ollama), plugin store, mini-apps SDK, cron scheduling, 6 messaging channels. SQLite, runs on a Pi. |


### PR DESCRIPTION
Adds [Aeon](https://github.com/aaronjmars/aeon) under **Local and Self-Hosted AI → Self-Hosted Agents and UIs**, alongside `openclaw-starter` and `KinBot`.

**What it is:** Autonomous agent framework that runs unattended on GitHub Actions. Configure once via `aeon.yml` and walk away — the agent picks from 90+ built-in skills (research, dev, crypto, productivity, social), runs them on cron or reactive triggers, scores its own output 1–5 via Haiku, and patches failing skills automatically.

**Why it fits the section:** Self-hosted (your own GitHub repo, no SaaS), zero infrastructure (GitHub Actions runs free on public repos), fork-and-run (private fork keeps memory and articles private). Same slot as `openclaw-starter`.

**Notable:**
- 255 stars, MIT
- 90+ skills, all independently installable (`./add-skill aaronjmars/aeon --list`)
- Self-healing loop: `heartbeat` → `skill-health` → `skill-evals` → `skill-repair` → `self-improve`
- MCP + A2A integrations (works with Claude Desktop, LangChain, AutoGen, CrewAI, OpenAI Agents SDK)
- Multi-channel notifications (Telegram, Discord, Slack, Email)