### PR TITLE
Add Mira to Cybersecurity Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,7 @@
 | [CrowdStrike Charlotte AI](https://crowdstrike.com) | AI security analyst. Threat hunting. |
 | [Prism Scanner](https://github.com/aidongise-cell/prism-scanner) | OSS security scanner for AI agent skills/plugins/MCP servers. Pre-install taint tracking, post-uninstall residue detection. |
 
+| [Mira](https://github.com/vwww-droid/Mira) | Runtime protection analysis for third-party Android and iOS apps. AI-accessible shell, Java, Native, and Frida capabilities for environment risk detection and hardening validation. |
 ---
 
 ## 🏥 Healthcare and Therapy Agents


### PR DESCRIPTION
## Summary
Add Mira to the Cybersecurity Agents section.

## Why
Mira is an Android and iOS runtime protection analysis platform for third-party target apps. It enables AI to use host-app-side shell, Java, Native, and Frida capabilities for environment risk detection and hardening validation.

## Project
- Repo: https://github.com/vwww-droid/Mira

## Notes
- Formatting matches existing entries.
- Entry is placed directly after the last existing item in the table.
