### PR TITLE
Add Suede to Music and Audio — x402-paid music/video generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@
 | [ElevenLabs Music](https://elevenlabs.io) | Vocals, instrumentals. Sectional editing. Stem separation. | Plan included |
 | [Stable Audio](https://stableaudio.com) | High-quality. Commercial license. | Free / Paid |
 | [Meta AudioCraft](https://github.com/facebookresearch/audiocraft) | OSS. MusicGen + AudioGen. | Free (OSS) |
+| [Suede](https://app.suedeai.xyz) | Music + video gen. Agent-callable via x402 (USDC on Base). On-chain ownership infra. | x402 pay-per-call / Plan |
 
 ### 3D and Design
 


### PR DESCRIPTION
Adds Suede to **Creative AI → Music and Audio** alongside Suno, Udio, ElevenLabs Music, Stable Audio, and Meta AudioCraft.

Suede is x402-paid AI music + video generation with on-chain ownership infrastructure. USDC on Base. ACP-ready commerce intent endpoint that lets autonomous agents call generation endpoints directly with HTTP 402 micropayments.

- Live app: https://app.suedeai.xyz
- OSS reference: https://github.com/Suede-AI/suede-x402-acp
- x402 endpoints: \`/agent/generate\`, \`/create-music\`, \`/agent/video\`
- Discovery: \`/.well-known/x402\`, \`/.well-known/agent-card.json\`