### PR TITLE
Add PromptEden to Tracing and Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,7 @@
 |------|-------------|
 | [Langfuse](https://github.com/langfuse/langfuse) | OSS LLM observability. Traces, evals, prompts. |
 | [LangSmith](https://smith.langchain.com) | LangChain platform. Tracing, testing, evaluation. |
+| [PromptEden](https://www.prompteden.com) | Monitor how ChatGPT, Claude, Gemini, Perplexity, Copilot, and Grok describe your brand — and which competitors they recommend instead. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback for AI agent config changes. Monitors health endpoint, reverts config + restarts service on failures. Zero deps. |
 | [Braintrust](https://braintrustdata.com) | Eval-driven development. Experiment tracking. |
 | [Arize Phoenix](https://github.com/Arize-ai/phoenix) | OSS AI observability. Traces, evals, embeddings. |


### PR DESCRIPTION
Adds [PromptEden](https://www.prompteden.com) to **Observability and Evaluation → Tracing and Monitoring**.

### What it is

PromptEden monitors how ChatGPT, Claude, Gemini, Perplexity, Copilot, and Grok describe your brand — and which competitors they recommend instead. It runs prompts daily across 9+ AI platforms and surfaces visibility scores, competitor mentions, and citation sources.

### Why it fits this list

The other tools in *Tracing and Monitoring* (Langfuse, LangSmith, Helicone, Arize Phoenix) monitor your *own* LLM apps. PromptEden is the external-facing complement — monitoring what public LLMs say about brands, which is increasingly load-bearing as AI assistants become a discovery surface. Adjacent in spirit to category leaders (Profound, Goodie, Otterly) emerging in 2025–2026.

### Checklist

- [x] Entry follows the section's existing 2-column format (`| Tool | Description |`)
- [x] Link is valid and points to official source
- [x] Description is concise (1 sentence) and factual — no promotional language
- [x] Project is publicly available, actively maintained (2025–2026)
- [x] Placed alphabetically near other LLM-monitoring tools

Happy to move it under *Data Analysis* or another section if you'd prefer — let me know.