### PR TITLE
Add OpenAgent to Agent Frameworks (General Purpose)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@
 | [Pydantic AI](https://github.com/pydantic/pydantic-ai) | Py | Type-safe. Clean Pythonic API. Production-ready. |
 | [DSPy](https://github.com/stanfordnlp/dspy) | Py | Stanford. Programming not prompting. Auto-optimizes. |
 | [Mastra](https://github.com/mastra-ai/mastra) | TS | TypeScript-first. Observational Memory. Apache 2.0. |
+| [OpenAgent](https://github.com/the-open-agent/openagent) | Go | Self-hostable assistant: LLM + RAG, computer/browser/coding agents, MCP, workflow UI. |
 | [Anthropic SDK](https://github.com/anthropics/anthropic-sdk-python) | Py/TS | Official Claude SDK. Tool use, computer control, streaming. |
 | [Google ADK](https://github.com/google/adk-python) | Py | ⭐ Google's Agent Development Kit. Native Gemini. Multi-agent orchestration. |
 


### PR DESCRIPTION
## Summary

Adds **OpenAgent** as a row in **Agent Frameworks → General Purpose**.

## About OpenAgent

Repository: https://github.com/the-open-agent/openagent  

Go codebase, Apache-2.0. Self-hostable assistant layer with LLM + RAG, MCP support, and workflows that cover coding plus browser / desktop-style automation.

**Links:** https://www.openagentai.org · https://demo.openagentai.org

Thanks for reviewing.