### PR TITLE
Add Friday Studio to Self-Hosted Agents and UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@
 | [LibreChat](https://github.com/danny-avila/LibreChat) | Self-hosted multi-model chat. All major providers. |
 | [LobeChat](https://github.com/lobehub/lobe-chat) | OSS ChatGPT/Gemini UI. Plugin system. Multi-modal. |
 | [KinBot](https://github.com/MarlBurroW/kinbot) | Self-hosted AI agent platform. Persistent memory (hybrid search + LLM re-ranking), 23+ providers (including Ollama), plugin store, mini-apps SDK, cron scheduling, 6 messaging channels. SQLite, runs on a Pi. |
+| [Friday Studio](https://github.com/friday-platform/friday-studio) | Self-hosted AI agent runtime ([hellofriday.ai](https://hellofriday.ai/)). Turns natural-language asks into versioned `workspace.yml` workflows — agents, MCP tools, skills, memory, and signals (HTTP, cron, Slack, email, webhook). Local-first daemon + SvelteKit playground; macOS desktop launcher. BSL 1.1 (Apache 2.0 after one year). |
 | [Anything LLM](https://github.com/Mintplex-Labs/anything-llm) | All-in-one AI app. RAG, agents. Desktop + Docker. |
 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | Data interaction with local LLM. 100% private. |
 


### PR DESCRIPTION
## Summary
- Adds [Friday Studio](https://github.com/friday-platform/friday-studio) ([hellofriday.ai](https://hellofriday.ai/)) to **Local and Self-Hosted AI → Self-Hosted Agents and UIs**.
- Friday is a self-hosted AI agent runtime that turns natural-language asks into versioned `workspace.yml` workflows — agents, MCP tools, skills, memory, and signals (HTTP, cron, Slack, email, webhook). Local-first daemon + SvelteKit playground, macOS desktop launcher. BSL 1.1 (converts to Apache 2.0 one year after release).
- Closest neighbor in that section is KinBot — both are self-hosted agent platforms with cron + multi-channel signals — so the entry is placed right after it.

## Test plan
- [x] Link points to official source (project site + GitHub repo)
- [x] Description is concise, factual, no promotional language
- [x] Markdown table row format matches the surrounding section
- [x] Pricing/license info current (BSL 1.1)