### PR TITLE
Add agent evaluation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,12 +490,12 @@
 | Tool | Description |
 |------|-------------|
 | [agent-skills-eval](https://github.com/darkrishabh/agent-skills-eval) | TypeScript SDK and CLI for evaluating agentskills.io-style skills with with-skill vs baseline runs, judge grading, JSONL logs, and static HTML reports. |
-| [Bench AI](https://github.com/darkrishabh/bench-ai) | CLI, web UI, and SDK for comparing LLM outputs, latency, tokens, and cost across models; supports YAML eval suites and judge-backed rubrics. |
 
 ### Benchmarks
 
 | Benchmark | Description |
 |-----------|-------------|
+| [Bench AI](https://github.com/darkrishabh/bench-ai) | CLI, web UI, and SDK for benchmarking LLM outputs, latency, tokens, and cost across models; supports YAML eval suites and judge-backed rubrics. |
 | [SWE-bench](https://github.com/princeton-nlp/SWE-bench) | Industry standard for coding agents. Top: 80.9% (Claude Opus 4.6). |
 | [AgentBench](https://github.com/THUDM/AgentBench) | 8-environment LLM agent benchmark. |
 | [Terminal-Bench](https://terminalbench.com) | Terminal agent performance. GPT-5.4 leads at 77.3%. |

--- a/README.md
+++ b/README.md
@@ -476,6 +476,8 @@
 
 | Tool | Description |
 |------|-------------|
+| [agent-skills-eval](https://github.com/darkrishabh/agent-skills-eval) | TypeScript SDK and CLI for evaluating agentskills.io-style skills with with-skill vs baseline runs, judge grading, JSONL logs, and static HTML reports. |
+| [Bench AI](https://github.com/darkrishabh/bench-ai) | CLI, web UI, and SDK for comparing LLM outputs, latency, tokens, and cost across models; supports YAML eval suites and judge-backed rubrics. |
 | [Langfuse](https://github.com/langfuse/langfuse) | OSS LLM observability. Traces, evals, prompts. |
 | [LangSmith](https://smith.langchain.com) | LangChain platform. Tracing, testing, evaluation. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback for AI agent config changes. Monitors health endpoint, reverts config + restarts service on failures. Zero deps. |

--- a/README.md
+++ b/README.md
@@ -476,8 +476,6 @@
 
 | Tool | Description |
 |------|-------------|
-| [agent-skills-eval](https://github.com/darkrishabh/agent-skills-eval) | TypeScript SDK and CLI for evaluating agentskills.io-style skills with with-skill vs baseline runs, judge grading, JSONL logs, and static HTML reports. |
-| [Bench AI](https://github.com/darkrishabh/bench-ai) | CLI, web UI, and SDK for comparing LLM outputs, latency, tokens, and cost across models; supports YAML eval suites and judge-backed rubrics. |
 | [Langfuse](https://github.com/langfuse/langfuse) | OSS LLM observability. Traces, evals, prompts. |
 | [LangSmith](https://smith.langchain.com) | LangChain platform. Tracing, testing, evaluation. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback for AI agent config changes. Monitors health endpoint, reverts config + restarts service on failures. Zero deps. |
@@ -486,6 +484,13 @@
 | [Helicone](https://github.com/Helicone/helicone) | OSS LLM observability. One-line integration. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback when your AI agent config breaks it. Zero deps, single Python file. Probes health endpoint, reverts config on failure. |
 | [Weights and Biases Weave](https://wandb.ai/site/weave) | Trace and evaluate LLM apps. |
+
+### Evaluation Tools
+
+| Tool | Description |
+|------|-------------|
+| [agent-skills-eval](https://github.com/darkrishabh/agent-skills-eval) | TypeScript SDK and CLI for evaluating agentskills.io-style skills with with-skill vs baseline runs, judge grading, JSONL logs, and static HTML reports. |
+| [Bench AI](https://github.com/darkrishabh/bench-ai) | CLI, web UI, and SDK for comparing LLM outputs, latency, tokens, and cost across models; supports YAML eval suites and judge-backed rubrics. |
 
 ### Benchmarks
 


### PR DESCRIPTION
## Summary
- Add agent-skills-eval to Observability and Evaluation
- Add Bench AI to Observability and Evaluation

Both are publicly available TypeScript tools for evaluating agent and LLM behavior.

## Checklist
- Links point to official GitHub repositories
- Descriptions are concise and factual
- README-only change