### PR TITLE
feat: add Dakera to RAG and Knowledge Bases section

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@
 | [KinBot](https://github.com/MarlBurroW/kinbot) | Self-hosted AI agent platform. Persistent memory (hybrid search + LLM re-ranking), 23+ providers (including Ollama), plugin store, mini-apps SDK, cron scheduling, 6 messaging channels. SQLite, runs on a Pi. |
 | [Anything LLM](https://github.com/Mintplex-Labs/anything-llm) | All-in-one AI app. RAG, agents. Desktop + Docker. |
 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | Data interaction with local LLM. 100% private. |
+| [Dakera](https://github.com/dakera-ai/dakera-mcp) | Self-hosted MCP-native agent memory server. 83 tools for persistent, decay-weighted episodic memory. RocksDB+HNSW, 87.8% LoCoMo benchmark, multi-SDK. |
 
 ---
 


### PR DESCRIPTION
## Add Dakera — Persistent Decay-Weighted Vector Memory MCP Server

**Dakera** is a production-grade AI agent memory server with an MCP interface providing 83 tools.

- **Repo:** https://github.com/Dakera-AI/dakera-mcp
- **Category:** RAG and Knowledge Bases

**Why it belongs here:**
- Directly addresses agent memory persistence and retrieval across sessions
- 83 MCP tools connecting directly to Claude, Cursor, Windsurf, and any MCP client
- Hybrid BM25+vector search for accurate recall
- Decay-weighted importance scoring — memories fade unless reinforced (like human memory)
- Knowledge graph construction and cross-agent memory sharing
- Self-hosted via Docker or `cargo install dakera-mcp` — no cloud lock-in

Added in alphabetical order within the RAG and Knowledge Bases section (after Nex, before Chroma).