### PR TITLE
docs(readme): add lucinate to Terminal and CLI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 | [Kilo Code](https://kilocode.ai) | Structured modes. Tighter context. | Free + API |
 | [OpenCode](https://github.com/opencode-ai/opencode) | BYOK terminal agent for Cursor refugees. | Free + API |
 | [Caliber](https://github.com/caliber-ai-org/ai-setup) | CLI that fingerprints projects and generates/syncs AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md). Scores quality. | Free + API |
+| [lucinate](https://github.com/lucinate-ai/lucinate) | Go-based terminal-native TUI chat client for OpenClaw, Hermes, and any OpenAI-compatible endpoint. Streaming, markdown, tool call cards, multi-agent. | Free (OSS) |
 
 ### Autonomous Software Engineers
 


### PR DESCRIPTION
Add [lucinate](https://github.com/lucinate-ai/lucinate) — a Go-based terminal-native TUI chat client for interacting with AI agents.

lucinate connects to OpenClaw gateways, Hermes agent profiles, and any OpenAI-compatible endpoint (Ollama, vLLM, LM Studio, OpenAI). It provides streaming responses, markdown rendering, tool call cards, local skills, cron management, session browsing, and multi-agent support — all from the terminal.

- **Section:** Terminal and CLI Agents
- **Public signal:** Active GitHub development, Homebrew tap (brew install lucinate-ai/tap/lucinate), cross-platform install scripts, public website at lucinate.ai, MIT licensed