### PR TITLE
Add Cordum to AI Governance and Compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,7 @@
 | [AuditOne](https://auditone.io) | Automated risk assessments and audit-ready documentation. |
 | [EU AI Act (Official)](https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai) | Official EU AI regulatory framework. Risk tiers: Unacceptable, High-Risk, Limited, Minimal. |
 | [NIST AI RMF](https://www.nist.gov/system/files/documents/2023/01/26/AI%20RMF%201.0.pdf) | US framework. Govern, Map, Measure, Manage. |
+| [Cordum](https://cordum.io) | Out-of-process governance control plane for autonomous AI agents. Pre-dispatch policy enforcement, approval gates, and signed audit trails. |
 
 ---
 


### PR DESCRIPTION
Adding [Cordum](https://cordum.io) to the AI Governance and Compliance section.

Cordum is an out-of-process governance control plane for autonomous AI agents. It runs as a separate process from the agent runtime and enforces policy before tool calls dispatch — so the audit trail and the enforcement decision are independent of the agent itself.

Distinct from in-process governance toolkits (e.g., Microsoft AGT) on the architectural axis the section already covers: trust-boundary separation between the enforcement layer and the agent. Relevant for SOC2 / EU AI Act / HIPAA audit contexts where the auditor needs the enforcement system to be independent of the system it governs.

Site: https://cordum.io. Repo: https://github.com/cordum-io/cordum. License: BUSL-1.1 (free self-host; commercial license for hosted/SaaS use).

New row added at the bottom of the existing table, matching column structure.