### PR TITLE
Add traceAI and ai-evaluation by Future AGI

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,8 @@
 | [Helicone](https://github.com/Helicone/helicone) | OSS LLM observability. One-line integration. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback when your AI agent config breaks it. Zero deps, single Python file. Probes health endpoint, reverts config on failure. |
 | [Weights and Biases Weave](https://wandb.ai/site/weave) | Trace and evaluate LLM apps. |
+| [traceAI](https://github.com/future-agi/traceAI) | OSS OpenTelemetry-native tracing. Auto-instruments 20+ AI frameworks and LLM providers, capturing prompts, tokens, latency, errors. |
+| [ai-evaluation](https://github.com/future-agi/ai-evaluation) | OSS LLM evaluation framework. 50+ metrics, LLM-as-Judge augmentation, guardrail scanners (jailbreak, PII, injection). |
 
 ### Benchmarks
 


### PR DESCRIPTION
traceAI is an open-source OpenTelemetry-native tracing framework. ai-evaluation is an open-source LLM evaluation framework. Added to Observability and Evaluation > Tracing and Monitoring.