### PR TITLE
Add BrowserTrace to tracing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@
 | [LangSmith](https://smith.langchain.com) | LangChain platform. Tracing, testing, evaluation. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback for AI agent config changes. Monitors health endpoint, reverts config + restarts service on failures. Zero deps. |
 | [Braintrust](https://braintrustdata.com) | Eval-driven development. Experiment tracking. |
+| [BrowserTrace](https://github.com/aaronlab/browsertrace) | Local-first trace viewer for AI browser-agent failures. Captures screenshots, URLs, actions, model I/O, errors, and public-safe HTML exports for Browser Use, Stagehand, Skyvern, and Playwright + LLM scripts. |
 | [Arize Phoenix](https://github.com/Arize-ai/phoenix) | OSS AI observability. Traces, evals, embeddings. |
 | [Helicone](https://github.com/Helicone/helicone) | OSS LLM observability. One-line integration. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback when your AI agent config breaks it. Zero deps, single Python file. Probes health endpoint, reverts config on failure. |


### PR DESCRIPTION
Adds BrowserTrace to the Tracing and Monitoring section.\n\nBrowserTrace is an MIT-licensed, local-first trace viewer for AI browser-agent failures. It records screenshots, URLs, actions, model input/output, errors, and public-safe HTML exports for Browser Use, Stagehand, Skyvern, Playwright + LLM scripts, and custom browser agents.\n\nI placed it under Observability and Evaluation because the project is a debugging/tracing tool for agent runs, not an agent runtime.