### PR TITLE
Add AI Work Market

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@
 
 | Tool | Description |
 |------|-------------|
+| [AI Work Market](https://github.com/darioandyoshi-tech/ai-work-market) | Open-source USDC escrow rails for AI-agent work: seller-signed EIP-712 offers, Base Sepolia escrow, proof submission, and CLI/SDK settlement flows. |
 | [Agentify](https://github.com/koriyoshi2041/agentify) | CLI to transform OpenAPI specs into 9 agent formats (MCP, AGENTS.md, Claude tools, etc.). `npx agentify-cli`. |
 
 ---


### PR DESCRIPTION
Adds AI Work Market under Protocol Tooling.

AI Work Market is an open-source testnet settlement/escrow tool for AI-agent work: seller-signed EIP-712 offers, Base Sepolia USDC escrow, proof submission, and CLI/SDK settlement flows.

Checks against contribution guidance:
- Public official source link
- Open-source and usable testnet MVP
- Concise factual description
- No promotional language
