### PR TITLE
Add Agent Amplifier to Context Optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@
 
 | Tool | Description |
 |------|-------------|
+| [Agent Amplifier](https://github.com/qualixar/agent-amplifier) | Runtime amplification layer for AI coding agents. Five Claude Code hooks add dynamic effort routing, goal anchoring, convergence detection, persona escalation, and token budgeting. Deterministic Python, zero extra LLM calls. Cross-host: Cursor, Copilot, LangGraph, CrewAI, AgentScope, LangChain. 1741 tests, 100% branch coverage. AGPL-3.0. |
 | [Entroly](https://github.com/juyterman1000/entroly) | Context engineering engine. 100% codebase visibility with 78% fewer tokens. Knapsack-optimal selection, SimHash dedup, RL from response quality. Rust engine, <10ms. MCP + HTTP proxy. |
 
 ### Tracing and Monitoring


### PR DESCRIPTION
Adding **Agent Amplifier v1.0.0** to `## 🔍 Observability and Evaluation > ### Context Optimization` — alphabetically before the existing Entroly entry.

## What it is

Agent Amplifier is a runtime amplification layer for AI coding agents. It installs as five Claude Code hooks (`UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`, `PreCompact`) and adds:

- Dynamic effort routing (5-tier complexity classifier)
- Goal anchor re-injection (anti-drift, every N tool calls)
- LTI-stability convergence detection
- Escalating persona audit per iteration
- Cost-bounded token budget controller
- MoE-inspired tool shortlisting

All in deterministic Python — zero extra LLM calls, zero network — installable in one line.

## Why "Context Optimization" fits

The category currently holds tools that shape what an agent sees (Entroly). Agent Amplifier shapes what an agent **does** with that context — effort routing, goal anchoring, convergence detection, token budgeting — at the hook layer, with no LLM calls of its own. Same category, complementary surface.

## Cross-host support

7 host adapters at launch: Claude Code, Cursor, GitHub Copilot, LangGraph, CrewAI, AgentScope, LangChain.

## Quality bar

- 1,741 tests
- 100% branch coverage
- `mypy --strict` clean
- `ruff` clean
- AGPL-3.0-or-later (commercial dual-license available)
- Dogfooded across 1.71 billion tokens / 22 sessions before shipping

## Links

- Repo: https://github.com/qualixar/agent-amplifier
- PyPI: https://pypi.org/project/agent-amplifier/
- npm: https://www.npmjs.com/package/agent-amplifier
- Demo (78s): https://youtube.com/watch?v=arfkIS00eKg

## CONTRIBUTING.md compliance checklist

- [x] Entry placed in correct section + alphabetical order (Agent < Entroly)
- [x] Link valid and points to official source
- [x] Description concise and factual (no promotional language)
- [x] Project meets "publicly available, actively maintained, not abandoned" criteria
- [x] Format matches existing rows in the section (2-column `| Tool | Description |`)

Happy to revise wording, move category, or adjust description length if you prefer.