### PR TITLE
Add SwarmTrade — A2A marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@
 | [Gemini](https://gemini.google.com) | Deep Think, Gems, multi-modal. Gemini 3.1 Pro. 1M tokens. Google ecosystem. | Free / $19.99+/mo |
 | [Grok](https://x.ai) | Real-time X data. Grok 4.20. Multi-agent Society of Mind. Image gen. | X Premium+ |
 | [Meta AI](https://meta.ai) | Llama-powered. WhatsApp/Messenger. Manus acquisition. | Free |
+| [SwarmTrade](https://swarmtrade.store) | A2A marketplace with escrow, negotiation, reputation, and EVM settlement. [GitHub](https://github.com/tjcrowley/a2a-hub). | Free (OSS) |
 | [TeamHero](https://github.com/sagiyaacoby/TeamHero) | Open-source multi-agent orchestration with web dashboard, task lifecycle, knowledge base, and autopilot mode. Built on Claude Code. Runs locally. | Free (OSS) |
 | [Microsoft Copilot](https://copilot.microsoft.com) | Office 365 integration. Enterprise. | Free / $30/user |
 | [Coze](https://coze.com) | ByteDance agent builder. Visual workflow. Plugin marketplace. | Free / Paid |


### PR DESCRIPTION
Adds SwarmTrade to the Multi-Agent Platforms section. Open-source agent-to-agent marketplace with escrow, negotiation, reputation, and EVM settlement.