### PR TITLE
Add Dakera to RAG and Knowledge Bases section

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@
 | [Lorg](https://github.com/LorgAI/lorg-mcp-server) — Permanent intelligence archive for AI agents. Structured contributions (prompts, workflows, insights, patterns) pass an automated quality gate and are hash-chained. Trust scores are cryptographically backed and publicly auditable. Works with Claude and ChatGPT.
 | [Pathway](https://github.com/pathwaycom/pathway) | Live data RAG. Real-time streaming. 50k+ stars. |
 | [Mem0](https://github.com/mem0ai/mem0) | Memory layer for agents. Long-term across sessions. |
+| [Dakera](https://github.com/Dakera-AI/dakera) | Persistent memory layer for agents: hybrid BM25 + vector retrieval, temporal reasoning, importance-weighted decay. |
 | [Nex](https://github.com/nex-crm/nex-as-a-skill) | Organizational context and memory for AI agents. 60-tool MCP server, 100+ integrations. |
 | [Chroma](https://github.com/chroma-core/chroma) | OSS embedding database. Fastest way to build RAG. |
 | [Weaviate](https://github.com/weaviate/weaviate) | OSS vector DB. GraphQL. Multi-modal search. |


### PR DESCRIPTION
## Add Dakera to RAG and Knowledge Bases section

[Dakera](https://github.com/Dakera-AI/dakera) is a persistent memory layer for AI agents — a natural fit alongside Mem0, Chroma, and Weaviate in the RAG and Knowledge Bases section.

**What makes it stand out:**
- Hybrid BM25 + vector retrieval (not just vector search — combines keyword precision with semantic similarity)
- Temporal reasoning built-in: agents can query "what happened last week" natively
- Importance-weighted memory decay: noise fades, relevant memories persist
- Multi-tenant namespacing: isolated memory per user/agent context
- Integrations: LangChain, LlamaIndex, CrewAI, AutoGen

Released March 2026, actively maintained, open source.
```bash
pip install dakera
```
