### PR TITLE
Add contextweaver to Context Optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@
 | Tool | Description |
 |------|-------------|
 | [Entroly](https://github.com/juyterman1000/entroly) | Context engineering engine. 100% codebase visibility with 78% fewer tokens. Knapsack-optimal selection, SimHash dedup, RL from response quality. Rust engine, <10ms. MCP + HTTP proxy. |
+| [contextweaver](https://github.com/dgenio/contextweaver) | Budget-aware context compilation and bounded-DAG tool routing for Python agents. Phase-specific token budgets (route/call/interpret/answer), context firewall for large tool outputs, deterministic by default. Framework-agnostic — adapters for MCP, A2A, LangChain, LlamaIndex, OpenAI Agents SDK, Google ADK, Pipecat. |
 
 ### Tracing and Monitoring
 


### PR DESCRIPTION
Adds [contextweaver](https://github.com/dgenio/contextweaver) to the **Context Optimization** subsection under Observability and Evaluation.

It's a Python library for budget-aware context compilation and bounded-DAG tool routing in tool-using agents — phase-specific token budgets (route / call / interpret / answer), a context firewall that keeps large tool outputs out of the prompt, and a deterministic-by-default pipeline. Apache-2.0, Python 3.10+, on PyPI, 600+ tests, minimal core deps.

Framework-agnostic with first-party adapters for MCP, A2A, LangChain, LlamaIndex, OpenAI Agents SDK, Google ADK, and Pipecat — sits alongside Entroly in the same category but covers the Python / framework-agnostic side of the same problem space.

Thanks for maintaining this list!