### PR TITLE
Add MisarBlog AI Agents — Content and Blogging Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,16 @@ MCP Server: [misarblog-mcp--misar.run.tools](https://misarblog-mcp--misar.run.to
 
 ---
 
+### ✍️ Content, Blogging and Newsletter Agents
+
+| Agent | Description | Pricing |
+|-------|-------------|---------|
+| [MisarBlog Writer](https://www.misar.blog) | Autonomous AI writing agent: researches topics, generates SEO-optimized titles, creates cover images, writes and publishes complete articles on Misar.Blog. MCP-powered. | Free w/ account |
+| [MisarBlog Growth](https://www.misar.blog) | Data-driven blog analytics and content strategy agent: surfaces top content, identifies gaps, manages content series on Misar.Blog. | Free w/ account |
+| [MisarBlog Community](https://www.misar.blog) | Community management agent: monitors comments/reactions, tracks followers, manages newsletter subscriber metrics for Misar.Blog creators. | Free w/ account |
+
+---
+
 
 ## ⚡ Task and Workflow Agents
 

--- a/README.md
+++ b/README.md
@@ -282,6 +282,21 @@
 
 ---
 
+## ✍️ Content and Blogging Agents
+
+### Blogging Platforms
+
+| Agent | Description | Pricing | Key Features |
+|-------|-------------|---------|--------------|
+| [MisarBlog Writer Agent](https://www.misar.blog) | Autonomous blog creation — researches topics, generates SEO-optimized titles, creates cover images, publishes articles end-to-end | Free (API key) | research_topic, suggest_titles, generate_cover_image, publish_article |
+| [MisarBlog Growth Agent](https://www.misar.blog) | Data-driven analytics and growth strategy — analyzes blog performance, identifies content gaps, manages content series | Free (API key) | get_analytics_summary, list_my_articles, create_series, add_to_series |
+| [MisarBlog Community Agent](https://www.misar.blog) | Community management — monitors comments, reactions, newsletter metrics in one digest | Free (API key) | list_comments, get_reactions, list_newsletter_subscribers, list_newsletter_issues |
+
+MCP Server: [misarblog-mcp--misar.run.tools](https://misarblog-mcp--misar.run.tools) · [Smithery](https://smithery.ai/server/misar/misarblog-mcp) · [GitHub](https://github.com/mrgulshanyadav/misarblog-mcp) · Get API key: [misar.blog/settings/api](https://www.misar.blog/settings/api)
+
+---
+
+
 ## ⚡ Task and Workflow Agents
 
 ### Automation


### PR DESCRIPTION
## What's being added

New section: **✍️ Content and Blogging Agents** with a Blogging Platforms subsection featuring three MCP-powered agents for Misar.Blog.

| Agent | Description | Pricing |
|-------|-------------|---------|
| MisarBlog Writer Agent | Autonomous blog creation (research → title → cover → publish) | Free |
| MisarBlog Growth Agent | Analytics, content gaps, series management | Free |
| MisarBlog Community Agent | Comments, reactions, newsletter digest | Free |

- Homepage: https://www.misar.blog
- MCP Server: https://misarblog-mcp--misar.run.tools
- Smithery: https://smithery.ai/server/misar/misarblog-mcp
- GitHub: https://github.com/mrgulshanyadav/misarblog-mcp
- License: MIT