### PR TITLE
Add APort to AI safety guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,7 @@
 
 | Tool | Description |
 |------|-------------|
+| [APort](https://aport.io) | Agent identity and policy enforcement for AI-agent tool calls, with [integration examples](https://github.com/aporthq/aport-integrations) for LangChain, CrewAI, Express, and FastAPI. |
 | [Guardrails AI](https://github.com/guardrails-ai/guardrails) | Structural, type, quality guarantees for LLM outputs. |
 | [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) | NVIDIA. Programmable conversation guardrails. |
 | [LLM Guard](https://github.com/protectai/llm-guard) | Security toolkit. Input/output scanning. |


### PR DESCRIPTION
## Summary
- Adds APort to the AI Safety and Guardrails section.
- Uses the existing two-column table format and links to official integration examples.

## Validation
- `git diff --check`
- Confirmed `https://aport.io` returns HTTP 200.
- Confirmed `https://github.com/aporthq/aport-integrations` returns HTTP 200.

Related bounty: https://github.com/aporthq/aport-integrations/issues/19

Payout:
- PayPal: https://paypal.me/Jeremytsangchina
- USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y