### PR TITLE
Add Polis Protocol to Multi-Agent Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@
 | [MagiC](https://github.com/kienbui1995/magic) | Go/Py | Kubernetes for AI agents. Manages any agent from any framework. Routing, cost control, DAG workflows, circuit breaker. |
 | [DeerFlow](https://github.com/bytedance/deer-flow) | Py | ByteDance. No.1 GitHub Trending Feb 2026. 25k+ stars. |
 | [AXME](https://github.com/AxmeAI/axme) | Py/TS/Go/Java/.NET | Durable coordination. Crash recovery, human approval gates, kill switch. Open protocol (AXP). |
+| [Polis Protocol](https://github.com/yehudalevy-collab/polis-protocol) | Py/MD | Vendor-agnostic markdown coordination layer. Signed capability cards, ε-greedy bandit routing that learns from settled contracts, chavruta paired review, self-amending constitution. Works across Claude Code, Codex, Gemini. |
 
 ### Lightweight / Minimalist
 


### PR DESCRIPTION
## Summary

Adds **Polis Protocol** to **🧱 Agent Frameworks → Multi-Agent Orchestration**.

## Why it fits this section

Sits alongside AXME as a "durable coordination" entry — but vendor-agnostic and markdown-native rather than runtime-coupled. Features:

- **Signed capability cards** per citizen agent
- **ε-greedy multi-armed bandit routing** that learns from settled-contract outcomes
- **Chavruta paired review** for high-stakes contracts
- **Ratifiable amendment process** for the protocol itself

Works across Claude Code, Codex, Gemini CLI, and any markdown-capable agent. MIT licensed.

Repo: https://github.com/yehudalevy-collab/polis-protocol
