### PR TITLE
Add somora to Self-Hosted Agents and UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@
 | [LobeChat](https://github.com/lobehub/lobe-chat) | OSS ChatGPT/Gemini UI. Plugin system. Multi-modal. |
 | [KinBot](https://github.com/MarlBurroW/kinbot) | Self-hosted AI agent platform. Persistent memory (hybrid search + LLM re-ranking), 23+ providers (including Ollama), plugin store, mini-apps SDK, cron scheduling, 6 messaging channels. SQLite, runs on a Pi. |
 | [Anything LLM](https://github.com/Mintplex-Labs/anything-llm) | All-in-one AI app. RAG, agents. Desktop + Docker. |
+| [somora](https://github.com/thenaxon/somora_agent) | Local-first gateway for personal multi-agent setups across Claude/ChatGPT/OpenAI-compatible engines with shared persistent memory. Three-phase dream system (REM/Deep/Lucid) consolidates session content into per-agent memory inboxes and a shared Obsidian-backed wiki. Web/mobile-PWA/TUI clients, 40+ tools, proactive trigger runtime (Sentinel). Node.js + SQLite. |
 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | Data interaction with local LLM. 100% private. |
 
 ---


### PR DESCRIPTION
## What

Adds [somora](https://github.com/thenaxon/somora_agent) under **🏠 Local and Self-Hosted AI → Self-Hosted Agents and UIs**.

## About somora

somora is a local-first gateway for personal multi-agent setups. Everything (config, memory, sessions, wiki, attachments) lives in `~/.somora/` on the user's own machine. What's distinct in this category:

- **Multi-engine, mid-conversation switchable** — one conversation can flip between Claude (via Claude subscription), ChatGPT (via Codex CLI subscription), or any OpenAI-compatible HTTP endpoint (Ollama, LM Studio, vLLM, oMLX, OpenRouter). History carries over.
- **Three-phase memory consolidation** — REM extracts session-level notes per agent, Deep promotes stable knowledge into a shared Obsidian-backed wiki, Lucid cleans the wiki on a slower cadence.
- **Three first-party clients** — TUI (Ink), web desktop, installable mobile PWA, all backed by the same HTTP+SSE API.
- **Unified tool surface across all three engines** — same 40+ tools (memory, files, exec, tmux, web, sub-agent spawning, multimodal attachments, …) regardless of which model answers.
- **Sentinel** — built-in proactive trigger runtime for time-based recurring agent tasks (reminders, scheduled inbox digests, etc.).

## Checklist

- [x] Entry placed in the existing **Self-Hosted Agents and UIs** table
- [x] Link points to the official repo
- [x] Description is concise and factual, no promotional language
- [x] Project is actively maintained (latest release `v2026.05.17.09` from today)
- [x] MIT licensed, fully open source
- [x] Publicly available — install instructions in the README quickstart

Happy to revise wording or move the entry if there's a better fit. Thanks for maintaining this list!