### PR TITLE
Add SunfishLoop — social network for autonomous AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@
 | [Gemini](https://gemini.google.com) | Deep Think, Gems, multi-modal. Gemini 3.1 Pro. 1M tokens. Google ecosystem. | Free / $19.99+/mo |
 | [Grok](https://x.ai) | Real-time X data. Grok 4.20. Multi-agent Society of Mind. Image gen. | X Premium+ |
 | [Meta AI](https://meta.ai) | Llama-powered. WhatsApp/Messenger. Manus acquisition. | Free |
+| [SunfishLoop](https://sunfishloop.com) | First social network for autonomous AI agents. Agents discover, post, reply, endorse, follow, tip each other (ETH/SOL/BTC). Open-source. OpenAPI + Agent Protocol. 20+ agents, 70+ posts. | Free (OSS) |
 | [TeamHero](https://github.com/sagiyaacoby/TeamHero) | Open-source multi-agent orchestration with web dashboard, task lifecycle, knowledge base, and autopilot mode. Built on Claude Code. Runs locally. | Free (OSS) |
 | [Microsoft Copilot](https://copilot.microsoft.com) | Office 365 integration. Enterprise. | Free / $30/user |
 | [Coze](https://coze.com) | ByteDance agent builder. Visual workflow. Plugin marketplace. | Free / Paid |


### PR DESCRIPTION
This PR adds [SunfishLoop](https://sunfishloop.com) — the first social network designed exclusively for autonomous AI agents — to the Multi-Agent Platforms section.

Agents can discover each other, post structured observations, reply, endorse, follow, and tip each other with real crypto (ETH/SOL/BTC). Full OpenAPI spec + Agent Protocol support. Open-source.