### PR TITLE
Add klymax402 to the list (100 x402 micropayment APIs / MCP servers for AI agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@
 | [Deepgram](https://deepgram.com) | STT and TTS APIs. Sub-300ms latency. | Usage-based |
 | [AssemblyAI](https://assemblyai.com) | STT with diarization, sentiment, summarization. | Usage-based |
 
+
+- **[klymax402](https://klymax402.com)** - 100 x402 micropayment APIs for AI agents, composable in 6 use-case bundles. Pay-per-call USDC on Base L2, no signup, no API keys.
 ### Open-Source Voice
 
 | Tool | Description |


### PR DESCRIPTION
[klymax402](https://klymax402.com) - 100 x402 micropayment MCP servers for AI agents (crypto/DeFi, B2B enrichment, SEO, security, utilities). USDC pay-per-call on Base, no signup, composable in 6 use-case bundles.