### PR TITLE
Add VaultForge — AI agent skill for Obsidian knowledge bases

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@
 | [Milvus](https://github.com/milvus-io/milvus) | Cloud-native vector DB. Billion-scale. |
 | [Pinecone](https://pinecone.io) | Managed vector DB. Serverless. Low-latency. |
 | [iGPT](https://igpt.ai) | Email Intelligence API. Converts email threads into reasoning-ready JSON for agents. |
+| [VaultForge](https://github.com/Easonnotsing/VaultForge) | AI agent skill transforming PDF/Markdown into structured Obsidian knowledge bases. 7-phase pipeline, incremental learning, 58 tests. Works with Claude Code, Codex, Cursor. |
 
 ---
 


### PR DESCRIPTION
Add **VaultForge** to the RAG and Knowledge Bases section.

VaultForge transforms PDF/Markdown learning materials into structured Obsidian vaults — atomic notes, MOCs, 5-type logical wikilinks, incremental learning, and Firecrawl/Exa deep research. Works with Claude Code, Codex, and Cursor. English & 中文, MIT licensed.

Repo: https://github.com/Easonnotsing/VaultForge
Release page: https://easonnotsing.github.io/VaultForge/