### PR TITLE
Add Beton Inspector to Sales and Outreach Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@
 | [Instantly](https://instantly.ai) | AI cold email. Unlimited accounts. Smart rotation. | From $30/mo |
 | [Overloop CLI](https://github.com/sortlist/overloop-cli) | AI outbound CLI. Source 450M+ contacts, email + LinkedIn campaigns, conversations. Agent-native JSON output. | $69-99/mo |
 | [Lavender](https://lavender.ai) | AI email coach. Real-time scoring. | Free / $29/mo |
+| [Beton Inspector](https://github.com/getbeton/inspector) | Open-source revenue intelligence. Scores accounts from PostHog product signals + CRM and routes the warmest leads to reps. Self-hostable. | Free (OSS) / SaaS |
 
 ---
 


### PR DESCRIPTION
Adding [Beton Inspector](https://github.com/getbeton/inspector) to **Sales and Outreach Agents**. Open-source (AGPL-3.0) revenue intelligence: an agentic pipeline scores accounts from PostHog product-usage signals + CRM and routes the warmest leads to reps. Self-hostable. Open-source alternative to Pocus / Common Room.