### PR TITLE
Add Alfred

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 
 | Agent | Description | Pricing |
 |-------|-------------|---------|
+| [Alfred](https://github.com/luminik-io/alfred-os) | Local agent-fleet runtime for Claude Code and Codex. GitHub issues become scheduled jobs with isolated worktrees, label state, review/test routing, and Slack reports. | Free (OSS) |
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Anthropic CLI agent. Best reasoning. 80.9% SWE-bench. Agent Teams feature. | $20/mo+ API |
 | [OpenAI Codex CLI](https://github.com/openai/codex) | OpenAI terminal agent. Agents SDK. Multi-agent. | ChatGPT sub |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | ⭐ **NEW (Apr 2026)** Google's official open-source terminal agent. ReAct loop. MCP support. 1M context. Apache 2.0. | Free w/ Google account |

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@
 | [Kilo Code](https://kilocode.ai) | Structured modes. Tighter context. | Free + API |
 | [OpenCode](https://github.com/opencode-ai/opencode) | BYOK terminal agent for Cursor refugees. | Free + API |
 | [Caliber](https://github.com/caliber-ai-org/ai-setup) | CLI that fingerprints projects and generates/syncs AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md). Scores quality. | Free + API |
-| [Alfred](https://github.com/luminik-io/alfred-os) | Local runtime for autonomous repo teammates on Claude Code and Codex. GitHub issues/specs become bounded runs with worktrees, label state, review/test routing, and Slack reports. | Free (OSS) |
+| [Alfred](https://github.com/luminik-io/alfred-os) | Local runtime that turns GitHub issues and specs into autonomous Claude Code and Codex runs. It uses labels, clean worktrees, review/test routing, and Slack reports. | Free (OSS) |
 
 ### Autonomous Software Engineers
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@
 | [Kilo Code](https://kilocode.ai) | Structured modes. Tighter context. | Free + API |
 | [OpenCode](https://github.com/opencode-ai/opencode) | BYOK terminal agent for Cursor refugees. | Free + API |
 | [Caliber](https://github.com/caliber-ai-org/ai-setup) | CLI that fingerprints projects and generates/syncs AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md). Scores quality. | Free + API |
-| [Alfred](https://github.com/luminik-io/alfred-os) | Local runtime that turns GitHub issues and specs into autonomous Claude Code and Codex runs. It uses labels, clean worktrees, review/test routing, and Slack reports. | Free (OSS) |
 
 ### Autonomous Software Engineers
 
@@ -91,6 +90,7 @@
 | [SWE-Agent](https://github.com/princeton-nlp/SWE-agent) | Princeton. Resolves real GitHub issues autonomously. | Free (OSS) |
 | [OpenHands](https://github.com/All-Hands-AI/OpenHands) | OSS autonomous software engineer (ex-OpenDevin). | Free (OSS) |
 | [Grok Build (xAI)](https://x.ai) | 8 parallel agents for code gen. Multi-agent "Society of Mind" architecture. | xAI sub |
+| [Alfred](https://github.com/luminik-io/alfred-os) | Self-hosted. GitHub issues to PRs via Claude Code and Codex on your subscription. Worktrees, label state, Slack reports. | Free (OSS) |
 
 ### Code Review and Security
 

--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@
 
 | Agent | Description | Pricing |
 |-------|-------------|---------|
-| [Devin](https://devin.ai) | Cognition. Fully autonomous. Sandboxed cloud env. Devin 2.0 with Interactive Planning. | $20/mo + ACU |
-| [Copilot Workspace](https://githubnext.com/projects/copilot-workspace) | GitHub issue-to-PR agent. | Copilot sub |
-| [SWE-Agent](https://github.com/princeton-nlp/SWE-agent) | Princeton. Resolves real GitHub issues autonomously. | Free (OSS) |
-| [OpenHands](https://github.com/All-Hands-AI/OpenHands) | OSS autonomous software engineer (ex-OpenDevin). | Free (OSS) |
-| [Grok Build (xAI)](https://x.ai) | 8 parallel agents for code gen. Multi-agent "Society of Mind" architecture. | xAI sub |
 | [Alfred](https://github.com/luminik-io/alfred-os) | Self-hosted. GitHub issues to PRs via Claude Code and Codex on your subscription. Worktrees, label state, Slack reports. | Free (OSS) |
+| [Copilot Workspace](https://githubnext.com/projects/copilot-workspace) | GitHub issue-to-PR agent. | Copilot sub |
+| [Devin](https://devin.ai) | Cognition. Fully autonomous. Sandboxed cloud env. Devin 2.0 with Interactive Planning. | $20/mo + ACU |
+| [Grok Build (xAI)](https://x.ai) | 8 parallel agents for code gen. Multi-agent "Society of Mind" architecture. | xAI sub |
+| [OpenHands](https://github.com/All-Hands-AI/OpenHands) | OSS autonomous software engineer (ex-OpenDevin). | Free (OSS) |
+| [SWE-Agent](https://github.com/princeton-nlp/SWE-agent) | Princeton. Resolves real GitHub issues autonomously. | Free (OSS) |
 
 ### Code Review and Security
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@
 
 | Agent | Description | Pricing |
 |-------|-------------|---------|
-| [Alfred](https://github.com/luminik-io/alfred-os) | Local agent-fleet runtime for Claude Code and Codex. GitHub issues become scheduled jobs with isolated worktrees, label state, review/test routing, and Slack reports. | Free (OSS) |
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Anthropic CLI agent. Best reasoning. 80.9% SWE-bench. Agent Teams feature. | $20/mo+ API |
 | [OpenAI Codex CLI](https://github.com/openai/codex) | OpenAI terminal agent. Agents SDK. Multi-agent. | ChatGPT sub |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | ⭐ **NEW (Apr 2026)** Google's official open-source terminal agent. ReAct loop. MCP support. 1M context. Apache 2.0. | Free w/ Google account |
@@ -81,6 +80,7 @@
 | [Kilo Code](https://kilocode.ai) | Structured modes. Tighter context. | Free + API |
 | [OpenCode](https://github.com/opencode-ai/opencode) | BYOK terminal agent for Cursor refugees. | Free + API |
 | [Caliber](https://github.com/caliber-ai-org/ai-setup) | CLI that fingerprints projects and generates/syncs AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md). Scores quality. | Free + API |
+| [Alfred](https://github.com/luminik-io/alfred-os) | Local agent-fleet runtime for Claude Code and Codex. GitHub issues become scheduled jobs with isolated worktrees, label state, review/test routing, and Slack reports. | Free (OSS) |
 
 ### Autonomous Software Engineers
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@
 | [Kilo Code](https://kilocode.ai) | Structured modes. Tighter context. | Free + API |
 | [OpenCode](https://github.com/opencode-ai/opencode) | BYOK terminal agent for Cursor refugees. | Free + API |
 | [Caliber](https://github.com/caliber-ai-org/ai-setup) | CLI that fingerprints projects and generates/syncs AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md). Scores quality. | Free + API |
-| [Alfred](https://github.com/luminik-io/alfred-os) | Local agent-fleet runtime for Claude Code and Codex. GitHub issues become scheduled jobs with isolated worktrees, label state, review/test routing, and Slack reports. | Free (OSS) |
+| [Alfred](https://github.com/luminik-io/alfred-os) | Local runtime for autonomous repo teammates on Claude Code and Codex. GitHub issues/specs become bounded runs with worktrees, label state, review/test routing, and Slack reports. | Free (OSS) |
 
 ### Autonomous Software Engineers
 


### PR DESCRIPTION
Adds Alfred to Terminal and CLI Agents. Alfred is an MIT-licensed local agent-fleet runtime for Claude Code and Codex, with GitHub issue claiming, isolated worktrees, label state, review/test routing, and Slack reports.

Source: https://github.com/luminik-io/alfred-os

Validation: git diff --check