### PR TITLE
Add Bounty Sieve

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,7 @@
 
 | Tool | Description |
 |------|-------------|
+| [Bounty Sieve](https://github.com/junbuilds96/bounty-sieve) | Offline-by-default intake guardrail for coding agents evaluating bounty-like GitHub issues. Read-only URL import, deterministic triage, local decision briefs, and an in-repo agent skill with human approval gates. |
 | [Guardrails AI](https://github.com/guardrails-ai/guardrails) | Structural, type, quality guarantees for LLM outputs. |
 | [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) | NVIDIA. Programmable conversation guardrails. |
 | [LLM Guard](https://github.com/protectai/llm-guard) | Security toolkit. Input/output scanning. |


### PR DESCRIPTION
Adds [Bounty Sieve](https://github.com/junbuilds96/bounty-sieve) to the AI Safety and Guardrails section.

Bounty Sieve is a small MIT-licensed CLI and in-repo agent skill for offline-by-default, read-only intake of bounty-like GitHub issues before coding agents act on them. It supports explicit GitHub issue URL / URL-list import, deterministic triage, local decision briefs, and human approval gates. It does not auto-claim, comment, star, clone, open PRs, connect wallets, or require credentials.

This seems to fit the guardrails section because it is focused on preventing unsafe/low-value agent work such as prompt/context exfiltration, wallet/secret access, star-gated bounties, and PR-spam-style tasks.
