### PR TITLE
Add Ejentum to AI Safety and Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,7 @@
 | [Rebuff](https://github.com/protectai/rebuff) | Prompt injection detection. |
 | [Lakera Guard](https://lakera.ai) | Real-time protection. Prompt injection, data leakage, toxicity. |
 | [OWASP Top 10 for Agentic Apps](https://owasp.org) | ⭐ **2026 Framework** Goal hijacking, tool misuse, cascading failure mitigations. |
+| [Ejentum](https://ejentum.com) | Reasoning harness. Four agentic tools (reasoning, code, anti-deception, memory) the agent calls during its loop; each returns a structured cognitive scaffold the model reads internally. Native integrations on PyPI / npm for LangChain, LangGraph.js, CrewAI, AutoGen, smolagents, Letta, PydanticAI, Agno, LlamaIndex, Vercel AI SDK, Mastra, Genkit. Also reachable via MCP. |
 
 ---
 


### PR DESCRIPTION
Adds **Ejentum** under `## 🛡 AI Safety and Guardrails`.

Ejentum is a pre-generation reasoning harness for agents. Four agent-callable tool modes (`reasoning`, `code`, `anti-deception`, `memory`) return structured cognitive scaffolds (named failure pattern, executable procedure, suppression vectors, falsification test) the model reads internally before producing its user-facing answer. The anti-deception mode is what makes the Guardrails section the right home — it catches sycophancy / hallucination / authority-appeal / fabricated-commitment failure patterns before generation, not after.

Twelve framework integrations shipped this month and live on PyPI / npm:

- Python (PyPI): `crewai-ejentum`, `agno-ejentum`, `pydantic-ai-ejentum`, `smolagents-ejentum` (live); `langchain-ejentum`, `llama-index-tools-ejentum`, `letta-ejentum`, `autogen-ejentum` (PyPI publish queued)
- TypeScript (npm): `ejentum-ai`, `ejentum-mastra`, `ejentum-langgraph`, `ejentum-genkit` (all live with OIDC provenance)
- Also reachable via MCP at `https://api.ejentum.com/mcp`

All under MIT license. Meets the contributing criteria (publicly available, actively maintained, format matches existing AI Safety and Guardrails table entries).

- Homepage: https://ejentum.com
- Pricing (free and paid tiers): https://ejentum.com/pricing
- Research paper ("Under Pressure", Zenodo): https://doi.org/10.5281/zenodo.19392715