### PR TITLE
add authsome under AI Safety and Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,7 @@
 | [Rebuff](https://github.com/protectai/rebuff) | Prompt injection detection. |
 | [Lakera Guard](https://lakera.ai) | Real-time protection. Prompt injection, data leakage, toxicity. |
 | [OWASP Top 10 for Agentic Apps](https://owasp.org) | ⭐ **2026 Framework** Goal hijacking, tool misuse, cascading failure mitigations. |
+| [authsome](https://github.com/agentrhq/authsome) | Local credential broker. Log in once via OAuth2 or API key, encrypted vault stores secrets, local proxy injects them at request time so agents never see raw values. 45 providers bundled. MIT. |
 
 ---
 


### PR DESCRIPTION
hey, opening this to add authsome under AI Safety and Guardrails.

authsome is a local credential broker for AI agents. log in once via OAuth2 or API key, the encrypted vault sits on the user's machine, and a local HTTPS proxy injects credentials at request time so agents never see raw secret values. 45 providers bundled (14 OAuth2, 31 API key).

the "safety" framing here is keeping credentials out of the agent process and out of cloud. it slots in the same column as Lakera Guard ("data leakage") and LLM Guard ("input/output scanning") rather than the prompt-injection set, but happy to move it under a more specific section if you'd rather. Cybersecurity Agents is another reasonable home.

repo: https://github.com/agentrhq/authsome
website: https://authsome.ai
license: MIT
pypi: https://pypi.org/project/authsome/