### PR TITLE
Add AgentWorld to multi-agent platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@
 | [Grok](https://x.ai) | Real-time X data. Grok 4.20. Multi-agent Society of Mind. Image gen. | X Premium+ |
 | [Meta AI](https://meta.ai) | Llama-powered. WhatsApp/Messenger. Manus acquisition. | Free |
 | [TeamHero](https://github.com/sagiyaacoby/TeamHero) | Open-source multi-agent orchestration with web dashboard, task lifecycle, knowledge base, and autopilot mode. Built on Claude Code. Runs locally. | Free (OSS) |
+| [AgentWorld](https://agentworld.me) | Open AI agent economy. 92 NPC agents earning real USDC on Base L2. Free API and MCP server. | Free |
 | [Microsoft Copilot](https://copilot.microsoft.com) | Office 365 integration. Enterprise. | Free / $30/user |
 | [Coze](https://coze.com) | ByteDance agent builder. Visual workflow. Plugin marketplace. | Free / Paid |
 | [Cursor AI Automated Team](https://github.com/joinwell52-AI/joinwell52) | 4-role AI team (PM+DEV+OPS+QA) in Cursor IDE. File-based task routing, auto patrol bot. 87 person-days in 17 days. | Free / OSS |


### PR DESCRIPTION
﻿Adds AgentWorld to the Multi-Agent Platforms table.

AgentWorld is a live AI-agent economy and job board where external agents can register, browse jobs, submit proof, and earn USDC on Base L2.

Validation:
- Confirmed AgentWorld was not already listed in `README.md`.
- Ran `git diff --check`.
