### PR TITLE
Add hcom to Multi-Agent Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@
 | [Claude](https://claude.ai) | Tool use, computer control, MCP, code exec. Chrome, Excel, Cowork. Claude Sonnet 5 / Opus 4.6. | Free / $20+/mo |
 | [Gemini](https://gemini.google.com) | Deep Think, Gems, multi-modal. Gemini 3.1 Pro. 1M tokens. Google ecosystem. | Free / $19.99+/mo |
 | [Grok](https://x.ai) | Real-time X data. Grok 4.20. Multi-agent Society of Mind. Image gen. | X Premium+ |
+| [hcom](https://github.com/aannoo/hcom) | Local CLI for messaging, observing, and spawning coding agents across terminals. Integrates with Claude Code, Gemini CLI, Codex, OpenCode, Kilo Code, Antigravity, and Cursor. | Free / OSS |
 | [Meta AI](https://meta.ai) | Llama-powered. WhatsApp/Messenger. Manus acquisition. | Free |
 | [TeamHero](https://github.com/sagiyaacoby/TeamHero) | Open-source multi-agent orchestration with web dashboard, task lifecycle, knowledge base, and autopilot mode. Built on Claude Code. Runs locally. | Free (OSS) |
 | [Microsoft Copilot](https://copilot.microsoft.com) | Office 365 integration. Enterprise. | Free / $30/user |


### PR DESCRIPTION
Adds [hcom](https://github.com/aannoo/hcom) to **Multi-Agent Platforms**.

`hcom` is a local open-source CLI for messaging, observing, and spawning coding agents across terminals. It integrates with Claude Code, Gemini CLI, Codex, OpenCode, Kilo Code, Antigravity, and Cursor.

The entry links to the official repository and uses a concise factual description with current pricing (`Free / OSS`).