### PR TITLE
Add Huiyu-Pi to Terminal and CLI Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!--lint disable awesome-heading awesome-github awesome-toc -->
+﻿<!--lint disable awesome-heading awesome-github awesome-toc -->
 
 <div align="center">
   <img src="assets/banner.svg" alt="Awesome AI Agents 2026" width="800">
@@ -80,7 +80,7 @@
 | [Kilo Code](https://kilocode.ai) | Structured modes. Tighter context. | Free + API |
 | [OpenCode](https://github.com/opencode-ai/opencode) | BYOK terminal agent for Cursor refugees. | Free + API |
 | [Caliber](https://github.com/caliber-ai-org/ai-setup) | CLI that fingerprints projects and generates/syncs AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md). Scores quality. | Free + API |
-| [Huiyu-Pi](https://github.com/huiyu9144/pi-forge) | Local-first AI coding agent with pure Web UI. ~80 token system prompt, ~0.3s first token latency, 90%+ lower cost. Self-hosted alternative to Claude Code/Codex CLI. | Free (OSS) |
+| [Huiyu-Pi](https://github.com/huiyu9144/Huiyu-Pi) | Local-first AI coding agent with pure Web UI. ~80 token system prompt, ~0.3s first token latency, 90%+ lower cost. Self-hosted alternative to Claude Code/Codex CLI. | Free (OSS) |
 
 ### Autonomous Software Engineers
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 | [Kilo Code](https://kilocode.ai) | Structured modes. Tighter context. | Free + API |
 | [OpenCode](https://github.com/opencode-ai/opencode) | BYOK terminal agent for Cursor refugees. | Free + API |
 | [Caliber](https://github.com/caliber-ai-org/ai-setup) | CLI that fingerprints projects and generates/syncs AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md). Scores quality. | Free + API |
+| [Huiyu-Pi](https://github.com/huiyu9144/pi-forge) | Local-first AI coding agent with pure Web UI. ~80 token system prompt, ~0.3s first token latency, 90%+ lower cost. Self-hosted alternative to Claude Code/Codex CLI. | Free (OSS) |
 
 ### Autonomous Software Engineers
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@
 | [Kilo Code](https://kilocode.ai) | Structured modes. Tighter context. | Free + API |
 | [OpenCode](https://github.com/opencode-ai/opencode) | BYOK terminal agent for Cursor refugees. | Free + API |
 | [Caliber](https://github.com/caliber-ai-org/ai-setup) | CLI that fingerprints projects and generates/syncs AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md). Scores quality. | Free + API |
-| [Huiyu-Pi](https://github.com/huiyu9144/Huiyu-Pi) | Local-first AI coding agent with pure Web UI. ~80 token system prompt, ~0.3s first token latency, 90%+ lower cost. Self-hosted alternative to Claude Code/Codex CLI. | Free (OSS) |
+| [Huiyu-Pi](https://github.com/huiyu9144/Huiyu-Pi) | Open-source local-first AI coding agent with pure Web UI. ~80 token system prompt, ~0.3s first token latency, 90%+ lower cost. Free self-hosted alternative to Claude Code/Codex CLI. | Free (OSS) |
 
 ### Autonomous Software Engineers
 


### PR DESCRIPTION
## Add Huiyu-Pi to awesome-ai-agents-2026

Open-source local-first AI coding agent with pure Web UI, ~80 token system prompt, ~0.3s first token latency, and 90%+ lower cost. Free self-hosted alternative to Claude Code / Codex CLI.

- **GitHub**: https://github.com/huiyu9144/Huiyu-Pi
- **License**: MIT
- **Category**: Coding Agents → Terminal and CLI Agents

It fits perfectly alongside Aider, Cline, OpenCode, and other OSS terminal agents as a self-hostable alternative with a pure web interface.