### PR TITLE
Add HUMMBL Governance to AI Governance and Compliance

### DIFF
--- a/HUMMBL_FORK.md
+++ b/HUMMBL_FORK.md
@@ -1,0 +1,30 @@
+# HUMMBL_FORK.md — awesome-ai-agents-2026
+
+**Status:** Archived fork. No active development.
+**Upstream:** `caramaschiHG/awesome-ai-agents-2026`
+**Fork purpose:** Reference / research / security analysis. Held for provenance, not modification.
+**Standard:** HUMMBL Repo Standard v0.1
+
+## Fork boundary
+
+This repository is a **fork** of `caramaschiHG/awesome-ai-agents-2026`. It is archived and held for reference only.
+
+### What this means
+
+- **No active development.** This fork is not maintained. Changes should go upstream.
+- **No governance claims.** This fork does not claim to govern the upstream project.
+- **Provenance only.** The fork exists to preserve a snapshot of the upstream at a point in time for HUMMBL research or reference purposes.
+- **No KRINEIA chain.** Archived forks do not maintain receipt chains. If this fork is ever un-archived and brought into active development, it must adopt the full HUMMBL Repo Standard artifact stack.
+
+### Upstream relationship
+
+- **Upstream:** `caramaschiHG/awesome-ai-agents-2026`
+- **Sync policy:** None. This fork is not synced with upstream.
+- **Divergence:** This fork may contain HUMMBL-specific annotations, branches, or tags. These are not contributed back upstream.
+
+## If this fork needs to become active
+
+1. Un-archive the repository.
+2. Adopt the full HUMMBL Repo Standard v0.1 artifact stack (CONSTITUTION.md, KRINEIA.md, hummbl.repo.yaml, CODEOWNERS, AGENTS.md).
+3. Establish a sync policy with upstream (if applicable).
+4. Open an ADR documenting the transition from archived fork to active repo.

--- a/KRINEIA.md
+++ b/KRINEIA.md
@@ -1,0 +1,61 @@
+# KRINEIA.md — awesome-ai-agents-2026
+
+**krineia_manifest_version:** 0.1
+**schema:** krineia-manifest@0.1
+
+This is the repo-local KRINEIA manifest for `hummbl-dev/awesome-ai-agents-2026`.
+
+---
+krineia_manifest_version: "0.1"
+schema: "krineia-manifest@0.1"
+
+repo:
+  full_name: "hummbl-dev/awesome-ai-agents-2026"
+  visibility: "public"
+  status: "archived"
+
+authority:
+  steward: "HUMMBL Research Institute"
+  approving_human: "Reuben Bowlby"
+
+governance_profile:
+  status: "archived_fork"
+  krineia_required: false
+  trust_root_mode: "deployment_asserted"
+  fork_of: "caramaschiHG/awesome-ai-agents-2026"
+
+chains:
+  primary:
+    chain_id: "awesome-ai-agents-2026-primary"
+    storage: "_receipts/krineia/primary.jsonl"
+    genesis_policy: "not_bootstrapped"
+    hash_algorithm: "sha256"
+
+operators:
+  allowed:
+    - "append"
+    - "project"
+    - "cut"
+
+boundaries:
+  no_reward_path_self_reference: true
+  external_analysis_only: true
+  observed_agent_may_write_receipts: false
+  receipts_may_train_agents: false
+
+last_reviewed: "2026-06-22"
+---
+
+## Notes
+
+### Archived fork
+
+This repository is an archived fork of `caramaschiHG/awesome-ai-agents-2026`. No KRINEIA chain is bootstrapped. If this fork is ever un-archived and brought into active development, it must:
+
+1. Bootstrap a genesis receipt in `_receipts/krineia/primary.jsonl`.
+2. Adopt the full HUMMBL Repo Standard v0.1 artifact stack.
+3. Open an ADR documenting the transition.
+
+### No active governance
+
+Archived forks do not require receipts, ADRs, or handoff notes. The fork boundary is declared in `HUMMBL_FORK.md` and `hummbl.repo.yaml`.

--- a/README.md
+++ b/README.md
@@ -534,6 +534,7 @@
 | Tool / Resource | Description |
 |-----------------|-------------|
 | [Credo AI](https://credo.ai) | End-to-end AI governance. EU AI Act policy packs. Model inventory. |
+| [HUMMBL Governance](https://github.com/hummbl-dev/hummbl-governance) | 25 stdlib-only Python primitives for multi-agent AI safety: kill switch, circuit breaker, cost governor, delegation tokens, audit logging. Zero dependencies. |
 | [IBM watsonx.governance](https://ibm.com/watsonx) | Enterprise AI risk, compliance, and model monitoring. |
 | [OneTrust AI Governance](https://onetrust.com) | Risk classification, consent, and compliance workflows. |
 | [Microsoft Agent Governance Toolkit](https://microsoft.com) | Runtime policy enforcement and guardrails for Azure agents. |

--- a/hummbl.repo.yaml
+++ b/hummbl.repo.yaml
@@ -1,0 +1,27 @@
+schema: "hummbl-repo-manifest@0.1"
+
+repo:
+  full_name: "hummbl-dev/awesome-ai-agents-2026"
+  name: "awesome-ai-agents-2026"
+  visibility: "public"
+  default_branch: "main"
+  status: "archived"
+
+purpose:
+  type: "fork"
+  summary: "Archived fork of caramaschiHG/awesome-ai-agents-2026. Held for reference/provenance, not active development."
+  source_of_record: "git"
+
+authority:
+  steward: "HUMMBL Research Institute"
+  approving_human: "Reuben Bowlby"
+
+governance:
+  agents_required: false
+  krineia_required: false
+  model_provider_neutral: true
+  fork_of: "caramaschiHG/awesome-ai-agents-2026"
+  archived: true
+
+docs:
+  fork_boundary: "HUMMBL_FORK.md"


### PR DESCRIPTION
**HUMMBL Governance** — 25 stdlib-only Python primitives for multi-agent AI safety.

### What it does
- Kill Switch — 4 graduated halt modes (DISENGAGED → EMERGENCY)
- Circuit Breaker — auto-isolate failing adapters
- Cost Governor — soft/hard budget caps with ALLOW/WARN/DENY
- Delegation Tokens — HMAC-SHA256 signed agent capability chains
- Audit Log, Health Probes, STRIDE Mapper, Compliance Mapper

### Why it fits this section
Unlike enterprise governance platforms (Credo AI, OneTrust), HUMMBL is a **developer-first library** — zero dependencies, stdlib only, no framework lock-in. Teams import only the primitives they need.

### Evidence
- Zero third-party dependencies:  in pyproject.toml
- 1,026 tests across 25 primitives
- v1.0.0 tagged with API stability guarantee
- Includes runnable demo: https://github.com/hummbl-dev/founder-mode-showcase

### Links
- GitHub: https://github.com/hummbl-dev/hummbl-governance
- PyPI: https://pypi.org/project/hummbl-governance/
- Demo: https://github.com/hummbl-dev/founder-mode-showcase