### PR TITLE
Add Mneme HQ to AI Governance and Compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@
 | [Microsoft Agent Governance Toolkit](https://microsoft.com) | Runtime policy enforcement and guardrails for Azure agents. |
 | [Bifrost](https://bifrost.ai) | Real-time security enforcement in agent pipelines. |
 | [AuditOne](https://auditone.io) | Automated risk assessments and audit-ready documentation. |
+| [Mneme HQ](https://mnemehq.com) | Open-source governance for AI coding agents. Compiles architectural decisions (ADRs) into deterministic constraints, enforced before generation. MIT-licensed. |
 | [EU AI Act (Official)](https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai) | Official EU AI regulatory framework. Risk tiers: Unacceptable, High-Risk, Limited, Minimal. |
 | [NIST AI RMF](https://www.nist.gov/system/files/documents/2023/01/26/AI%20RMF%201.0.pdf) | US framework. Govern, Map, Measure, Manage. |
 


### PR DESCRIPTION
Adds **Mneme HQ** to the **AI Governance and Compliance** section.

Mneme HQ is an open-source (MIT) governance layer for AI coding agents. It compiles architectural decision records (ADRs) into a deterministic constraint set and enforces them at the prompt boundary, before Claude Code / Cursor generate code.

- Publicly available: `pip install mneme` (PyPI) + https://github.com/TheoV823/mneme
- Actively maintained
- Link valid, description factual, no promotional language
- Grouped with the governance tools, ahead of the official frameworks (EU AI Act, NIST)