### PR TITLE
Add grite

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Anthropic CLI agent. Best reasoning. 80.9% SWE-bench. Agent Teams feature. | $20/mo+ API |
 | [OpenAI Codex CLI](https://github.com/openai/codex) | OpenAI terminal agent. Agents SDK. Multi-agent. | ChatGPT sub |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | ⭐ **NEW (Apr 2026)** Google's official open-source terminal agent. ReAct loop. MCP support. 1M context. Apache 2.0. | Free w/ Google account |
+| [grite](https://github.com/neul-labs/grite) | Git-backed issue tracker for AI coding agents. CRDT-merged event log in `refs/grite/wal` syncs via `git push`/`fetch`. Stable `--json` output and `grite install-skill` for Claude Code. | Free (OSS) |
 | [Aider](https://github.com/paul-gauthier/aider) | OSS pair programmer. Git-aware. Any LLM. | Free + API |
 | [Cline](https://github.com/cline/cline) | VS Code extension. Full terminal and browser access for Claude/GPT. | Free + API |
 | [RooCode](https://github.com/RooVetGit/Roo-Code) | Cline fork. Structured modes. Reduced hallucinations. | Free + API |


### PR DESCRIPTION
Adds grite (https://github.com/neul-labs/grite) — a git-backed, repo-local issue tracker with CRDT-based conflict-free merging, designed for AI coding agents. Issues are stored as an append-only event log in `refs/grite/wal` and sync via `git push`/`fetch`, requiring no server or database. Stable `--json` output and a `grite install-skill` command make it scriptable from agents like Claude Code. MIT licensed.

Placed alphabetically in **Coding Agents → Terminal and CLI Agents**, between Gemini CLI and Aider.