### PR TITLE
docs(taskade): Add Taskade AI agents guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@
 | [Rivet](https://rivet.ironcladapp.com) | Visual AI workflow builder. Drag-and-drop. | Free (OSS) |
 | [FastAgency](https://github.com/airtai/fastagency) | Deploy multi-agent workflows as APIs. | Free (OSS) |
 | [cstack](https://github.com/srf6413/cstack) | Architecture pattern for autonomous agents using Claude Cowork, Notion, and MCP. Persistent multi-domain agents with no custom infrastructure or code. | Free |
+| [Taskade](https://docs.taskade.com/genesis-living-system-builder/ai-features/ai-agents-getting-started.md) | Complete guide for deploying AI agents with persistent memory, custom tools, and integrations on Taskade. Includes agent frameworks, workflows, and MCP protocol integration. | Free / Paid |
 
 ---
 


### PR DESCRIPTION
Adds Taskade AI agents documentation — covers building custom agents with persistent memory, tools, workflows, and MCP integration.

- Links to comprehensive Taskade agent getting started guide
- Positioned in No-Code Agent Builders subsection under Task and Workflow Agents
- Highlights persistent memory, custom tools, and MCP protocol support