### PR TITLE
Add TWZRD Agent Intel - Solana AI agent trust scoring via x402

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@
 | [Tool Use (Anthropic)](https://docs.anthropic.com/en/docs/build-with-claude/tool-use) | Claude native tool-use. Structured JSON. |
 | [OpenAPI](https://github.com/OAI/OpenAPI-Specification) | Industry-standard API spec. Foundation for agent tools. |
 | [HCS (Hashgraph Consensus Service)](https://hol.org) | Hedera open standards for agent identity (HCS-14 UAIDs), trustless P2P communication (HCS-10), and cross-protocol bridging. 187K+ verified agents. |
+| **[TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final)** | Solana-native AI agent trust scoring via x402 micropayments — free on-chain preflight checks + paid signed V5 trust receipts settled in <1s. |
 
 ### Protocol Tooling
 


### PR DESCRIPTION
## Summary

Adds **[TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final)** to the **Protocols and Standards** section, alongside HCS (agent identity/trust) and other agent infrastructure entries.

**What it is:** Solana-native AI agent trust scoring infrastructure via x402 micropayments — free on-chain preflight checks + paid signed V5 trust receipts settled in <1s.

- Protocol: x402 (HTTP 402 micropayments, USDC on Solana)
- MCP endpoint: https://intel.twzrd.xyz/mcp (Streamable-HTTP)
- Repo: https://github.com/twzrd-sol/wzrd-final

Fits the Protocols and Standards section alongside agent identity and trust infrastructure (e.g. HCS).