### PR TITLE
Add AgentLine to Voice Agents — Platforms and APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@
 | [HeyGen](https://heygen.com) | Talking avatars. Voice cloning. Lip-sync translation. | From $24/mo |
 | [Synthesia](https://synthesia.io) | AI video avatars. 120+ languages. Enterprise. | From $22/mo |
 | [Deepgram](https://deepgram.com) | STT and TTS APIs. Sub-300ms latency. | Usage-based |
+| [AgentLine](https://agentline.cloud/) | Telephony infrastructure for AI agents — provision phone numbers, make/receive calls, and manage voice pipelines via API. | Usage-based |
 | [AssemblyAI](https://assemblyai.com) | STT with diarization, sentiment, summarization. | Usage-based |
 
 ### Open-Source Voice


### PR DESCRIPTION
## Summary

Adds [AgentLine](https://agentline.cloud/) to the 🎙 Voice Agents → Platforms and APIs table.

AgentLine provides telephony infrastructure for AI agents — provision phone numbers, make/receive calls, and manage voice pipelines via API. 30+ paid users.

## Checklist

- [x] Directly related to AI agents (voice/telephony infra)
- [x] Actively maintained (live SaaS)
- [x] Publicly available
- [x] Not a duplicate
- [x] Functional