### PR TITLE
Add TWZRD Agent Intel — AI agent trust scoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@
 | [Tool Use (Anthropic)](https://docs.anthropic.com/en/docs/build-with-claude/tool-use) | Claude native tool-use. Structured JSON. |
 | [OpenAPI](https://github.com/OAI/OpenAPI-Specification) | Industry-standard API spec. Foundation for agent tools. |
 | [HCS (Hashgraph Consensus Service)](https://hol.org) | Hedera open standards for agent identity (HCS-14 UAIDs), trustless P2P communication (HCS-10), and cross-protocol bridging. 187K+ verified agents. |
+| **[TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final)** | Solana-native AI agent trust scoring via x402 micropayments — free on-chain preflight checks + paid signed V5 trust receipts settled in <1s. |
 
 ### Protocol Tooling
 

--- a/README.md
+++ b/README.md
@@ -525,6 +525,7 @@
 | [Rebuff](https://github.com/protectai/rebuff) | Prompt injection detection. |
 | [Lakera Guard](https://lakera.ai) | Real-time protection. Prompt injection, data leakage, toxicity. |
 | [OWASP Top 10 for Agentic Apps](https://owasp.org) | ⭐ **2026 Framework** Goal hijacking, tool misuse, cascading failure mitigations. |
+| [TWZRD Agent Intel](https://intel.twzrd.xyz) | Solana-native MCP server for AI agent trust verification. Free preflight trust scoring + paid signed x402 receipts anchored on-chain. Streamable-HTTP endpoint at https://intel.twzrd.xyz/mcp. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@
 | [Tool Use (Anthropic)](https://docs.anthropic.com/en/docs/build-with-claude/tool-use) | Claude native tool-use. Structured JSON. |
 | [OpenAPI](https://github.com/OAI/OpenAPI-Specification) | Industry-standard API spec. Foundation for agent tools. |
 | [HCS (Hashgraph Consensus Service)](https://hol.org) | Hedera open standards for agent identity (HCS-14 UAIDs), trustless P2P communication (HCS-10), and cross-protocol bridging. 187K+ verified agents. |
-| **[TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final)** | Solana-native AI agent trust scoring via x402 micropayments — free on-chain preflight checks + paid signed V5 trust receipts settled in <1s. |
+| **[TWZRD Agent Intel](https://intel.twzrd.xyz)** | Solana-native AI agent trust scoring via x402 micropayments — free on-chain preflight checks + paid signed V5 trust receipts settled in <1s. |
 
 ### Protocol Tooling
 


### PR DESCRIPTION
## Summary

Adds **[TWZRD Agent Intel](https://intel.twzrd.xyz)** to the AI Safety and Guardrails section.

**What it is:** Solana-native MCP server for AI agent trust verification — addresses a gap in the guardrails ecosystem: *who is the agent you're about to transact with, and does it have a trustworthy history?*

- **Free preflight trust scoring**: on-chain history check before agent-to-agent interactions
- **Paid signed x402 receipts**: cryptographic proof of trust assessment, anchored to Solana transactions and settled in <1s
- **MCP endpoint**: `https://intel.twzrd.xyz/mcp` (Streamable-HTTP, compatible with any MCP-capable framework)
- **Website**: https://intel.twzrd.xyz

**Why it fits the Safety & Guardrails section**: In multi-agent systems, verifying counterparty identity and on-chain history before transactions is a form of deployment-time safety infrastructure — complementary to prompt injection defense and output guardrails, but addressing the trust layer.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)