### PR TITLE
Add agent-qa

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@
 
 | Tool | Description |
 |------|-------------|
+| [agent-qa](https://github.com/vostride/agent-qa) | Self-improving agentic QA harness for natural-language web test execution with memory and self-healing browser actions. |
 | [Browser Use](https://github.com/browser-use/browser-use) | OSS browser agent library. Used by Manus. |
 | [Skyvern](https://github.com/Skyvern-AI/skyvern) | Vision-driven. GPT-4V navigation without coded selectors. |
 | [Agent S2 (Simular)](https://github.com/simular-ai/Agent-S) | OSS GUI automation framework. |


### PR DESCRIPTION
Adds agent-qa to the Browser and Desktop Agents / Developer Infrastructure section.

agent-qa is a maintained agentic QA harness for natural-language web test execution with memory and self-healing browser actions. It fits this section as developer infrastructure for running browser-facing agent QA workflows.

Checks:
- Entry is in the existing table format.
- Link points to the public repository.
- Description is concise and factual.
- I searched the README and did not find a duplicate.

Affiliation disclosure: I am affiliated with agent-qa.
