### PR TITLE
Add DiamantAI to Newsletters and Communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,7 @@
 | [Latent Space](https://www.latent.space/) | AI engineering podcast (Swyx + Alessio) |
 | [The Rundown AI](https://therundown.ai) | Daily digest (600k+ subs) |
 | [Ben's Bites](https://bensbites.co) | Daily AI with builder focus |
+| [DiamantAI](https://diamantai.substack.com) | Practical AI engineering and GenAI: RAG, agents, LLM application patterns |
 | [State of Agent Engineering](https://www.langchain.com/state-of-agent-engineering) | Annual report (1,300+ surveyed) |
 | [r/LangChain](https://reddit.com/r/LangChain) | Agent developer community |
 | [r/ClaudeAI](https://reddit.com/r/ClaudeAI) | Claude community |


### PR DESCRIPTION
Adding DiamantAI to the Newsletters and Communities table.

[DiamantAI](https://diamantai.substack.com) covers practical AI engineering and generative AI (RAG, agents, LLM application patterns) for builders.

Disclosure: this is my newsletter.