### PR TITLE
Add cv.cm/v

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@
 | [Wan 2.1](https://github.com/Wan-Video/Wan2.1) | Best free OSS video gen. Self-hostable. No limits. | Free (OSS) |
 | [HunyuanVideo](https://github.com/Tencent/HunyuanVideo) | Tencent OSS. Consumer GPU. Multi-style. | Free (OSS) |
 | [LTX Video](https://github.com/Lightricks/LTX-Video) | OSS. Licensed data. Clear commercial terms. | Free (OSS) |
+| [cv.cm/v](https://cv.cm/v) | Queue-free Seedance 2.0 text/image-to-video, plus gpt-image-2/Seedream images and an open API. | Free credits |
 
 ### Music and Audio
 


### PR DESCRIPTION
Adds **cv.cm/v** to Creative AI → Video Generation.

cv.cm/v offers queue-free, full-power Seedance 2.0 text-to-video and image-to-video, plus gpt-image-2/Seedream image generation and an open developer API. It also includes a one-sentence short-drama agent. New users get free credits (Pricing: Free credits).