### PR TITLE
Add Respan to Tracing and Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@
 | [Arize Phoenix](https://github.com/Arize-ai/phoenix) | OSS AI observability. Traces, evals, embeddings. |
 | [Helicone](https://github.com/Helicone/helicone) | OSS LLM observability. One-line integration. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback when your AI agent config breaks it. Zero deps, single Python file. Probes health endpoint, reverts config on failure. |
+| [Respan](https://www.respan.ai/ai-gateway) | LLM and agent observability. Traces, evals, prompts, gateway across 250+ models. |
 | [Weights and Biases Weave](https://wandb.ai/site/weave) | Trace and evaluate LLM apps. |
 
 ### Benchmarks


### PR DESCRIPTION
Adds Respan to Observability and Evaluation -> Tracing and Monitoring. Respan is an LLM and agent observability platform with tracing, evals, prompt management, and a gateway across 250+ models.
Placed in alphabetical position; link points to the official site.
