### PR TITLE
Add: Dedicated Mac Mini AI Bot Setup (managed Mac mini AI agent service)

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,13 +417,14 @@
 | Tool | Description |
 |------|-------------|
 | [Open WebUI](https://github.com/open-webui/open-webui) | Self-hosted ChatGPT UI. Access control. Extensions. |
-| [OpenClaw](https://github.com/openclaw/openclaw) | Fastest-growing GitHub repo ever (9k to 188k stars in 60 days). Self-hosted agent across WhatsApp, Telegram, Slack, Discord, Signal. 5,700+ community skills. | 
+| [OpenClaw](https://github.com/openclaw/openclaw) | Self-hosted agent across WhatsApp, Telegram, Slack, Discord, Signal. 5,700+ community skills. | 
 | [openclaw-starter](https://github.com/feralghost/openclaw-starter) | Fork-and-run template for 24/7 autonomous AI agents. Pre-configured SOUL.md, memory system, KANBAN, heartbeat. Start in 30 minutes. |
 | [LibreChat](https://github.com/danny-avila/LibreChat) | Self-hosted multi-model chat. All major providers. |
 | [LobeChat](https://github.com/lobehub/lobe-chat) | OSS ChatGPT/Gemini UI. Plugin system. Multi-modal. |
 | [KinBot](https://github.com/MarlBurroW/kinbot) | Self-hosted AI agent platform. Persistent memory (hybrid search + LLM re-ranking), 23+ providers (including Ollama), plugin store, mini-apps SDK, cron scheduling, 6 messaging channels. SQLite, runs on a Pi. |
 | [Anything LLM](https://github.com/Mintplex-Labs/anything-llm) | All-in-one AI app. RAG, agents. Desktop + Docker. |
 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | Data interaction with local LLM. 100% private. |
+| [Dedicated Mac Mini AI Bot Setup](https://www.emadibrahim.com/bot-setup/mac-mini-ai-agent-setup) | Managed Mac mini AI agent setup service accessible via Telegram and Discord, with pre-configured workflows for marketing, SEO, email, coding, deployment, QA, research, and operations. $1,000 setup + $100/mo. (managed service) |
 
 ---
 


### PR DESCRIPTION
## Summary

Add **Dedicated Mac Mini AI Bot Setup** — a managed Mac mini AI agent setup service accessible via Telegram and Discord.


## Why this fits

- **Self-hosted AI agent service** with pre-configured multi-domain workflows (marketing, SEO, email, coding, deployment QA, research, operations)
- **Differentiator**: dedicated hardware (Mac mini) for privacy-conscious users
- **Active service** with ongoing maintenance ($100/mo)
- Category: `Local and Self-Hosted AI → Self-hosted Agents and UIs`


## Changes

1. **Add new entry** for Dedicated Mac Mini AI Bot Setup (inserted alphabetically after DB-GPT)
2. **Fix OpenClaw promotional language** — removed "Fastest-growing GitHub repo ever (9k to 188k stars in 60 days)" which violates CONTRIBUTING.md rules against promotional language

## Pricing

$1,000 setup + $100/month (disclosed transparently)


## Disclosure

No financial or personal relationship with the operators of this service.

## Note for maintainers

> ⚠️ **GDPR/Privacy note**: This entry references a third-party managed service. The repository maintainer should review whether a privacy policy or GDPR disclosure is appropriate, particularly if user data or API calls to Telegram/Discord are involved.

Closes #304