### PR TITLE
Add NarraNexus to Multi-Agent Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@
 | [Microsoft Copilot](https://copilot.microsoft.com) | Office 365 integration. Enterprise. | Free / $30/user |
 | [Coze](https://coze.com) | ByteDance agent builder. Visual workflow. Plugin marketplace. | Free / Paid |
 | [Cursor AI Automated Team](https://github.com/joinwell52-AI/joinwell52) | 4-role AI team (PM+DEV+OPS+QA) in Cursor IDE. File-based task routing, auto patrol bot. 87 person-days in 17 days. | Free / OSS |
+| [NarraNexus](https://github.com/NetMindAI-Open/NarraNexus) | Open-source AI agent team workspace: memory-aware agents with persistent context across sessions, multi-agent collaboration (PM, developer, deployment, research), and MCP-style tools. Browser dashboard, macOS, cloud, and local. | Open-source |
 
 ---
 


### PR DESCRIPTION
Adds **NarraNexus** (https://github.com/NetMindAI-Open/NarraNexus) to the Multi-Agent Platforms table.

Open-source AI agent team workspace: memory-aware agents with persistent context across sessions, multi-agent collaboration (PM, developer, deployment, research), and MCP-style tool integrations. Browser dashboard, macOS app, cloud, and local source deployment.