### PR TITLE
feat: add CreatorSkills to Creative AI > Content Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,12 @@
 | [Tripo AI](https://tripo3d.ai) | Fast 3D from text/images. Multi-format export. | Free / Paid |
 | [Vizcom](https://vizcom.ai) | Real-time AI rendering for industrial designers. | From $20/mo |
 
+### Content Creation
+
+| Tool | Description | Pricing |
+|------|-------------|---------|
+| [CreatorSkills](https://creatorskills.co) | Marketplace for AI skills (SKILL.md instruction packages) for content creators — YouTube scripting, sponsorship analysis, repurposing. Installs into Claude, ChatGPT, and 20+ agents. | Free / $9–$49 |
+
 ---
 
 ## ⚡ Task and Workflow Agents


### PR DESCRIPTION
## What's being added

[CreatorSkills](https://creatorskills.co) — a marketplace for AI skills targeting content creators.

Added as a new **Content Creation** subsection under **Creative AI**, since it equips content creator workflows (YouTube, podcasts, newsletters) with specialized AI agent capabilities.

**Entry:**

| Tool | Description | Pricing |
|------|-------------|---------|
| [CreatorSkills](https://creatorskills.co) | Marketplace for AI skills (SKILL.md instruction packages) for content creators — YouTube scripting, sponsorship analysis, repurposing. Installs into Claude, ChatGPT, and 20+ agents. | Free / $9–$49 |

**Why it fits:** CreatorSkills distributes agent skills in the SKILL.md open standard (the format behind agentskills.io, already widely referenced in the agent ecosystem). It fills a niche not currently in the list — a marketplace aimed specifically at the creator economy rather than dev/enterprise users.

Meets the criteria: publicly available, actively maintained, 2026.