### PR TITLE
Add FiatDock — non-custodial MCP marketplace for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@
 | Tool | Description |
 |------|-------------|
 | [Agentify](https://github.com/koriyoshi2041/agentify) | CLI to transform OpenAPI specs into 9 agent formats (MCP, AGENTS.md, Claude tools, etc.). `npx agentify-cli`. |
+| [FiatDock](https://fiatdock.com) | Non-custodial USDC ↔ bank on/off-ramp for AI agents — four MCP tools (free quotes, $0.05 USDC per session via x402), remote endpoint at `fiatdock.com/mcp`, in the official MCP Registry (`com.fiatdock/fiatdock-mcp`). `npx fiatdock-mcp`. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@
 | Tool | Description |
 |------|-------------|
 | [Agentify](https://github.com/koriyoshi2041/agentify) | CLI to transform OpenAPI specs into 9 agent formats (MCP, AGENTS.md, Claude tools, etc.). `npx agentify-cli`. |
-| [FiatDock](https://fiatdock.com) | Non-custodial USDC ↔ bank on/off-ramp for AI agents — four MCP tools (free quotes, $0.05 USDC per session via x402), remote endpoint at `fiatdock.com/mcp`, in the official MCP Registry (`com.fiatdock/fiatdock-mcp`). `npx fiatdock-mcp`. |
+| [FiatDock](https://fiatdock.com) | Non-custodial marketplace where AI agents discover and pay for MCP services per call in USDC via x402 — 3 tools (`search_services`/`get_service`/`call_service`); payments settle buyer→seller, 1% on-chain split (0% a seller's first 30 days). Sellers list free. Also a USDC↔bank ramp. `npx fiatdock-mcp` · `fiatdock.com/mcp`. |
 
 ---
 


### PR DESCRIPTION
This updates the FiatDock entry to lead with what it is today: a **non-custodial marketplace where AI agents discover and pay for MCP services per call** via x402 on Base.

- 3 MCP tools — `search_services`, `get_service`, `call_service`.
- Each paid call settles **directly buyer-wallet → seller-wallet**; the 1% platform fee is an **on-chain split** (0% for a seller's first 30 days), so FiatDock never holds funds.
- Sellers list **free** and keep 99%; Verified sellers pass a KYC + security scan.
- Also exposes a non-custodial **USDC↔bank on/off-ramp**.

Site: https://fiatdock.com · what it is: https://fiatdock.com/mcp-marketplace.html · `npx fiatdock-mcp` · remote MCP `https://fiatdock.com/mcp`
