### PR TITLE
Add OpenClaw Monitor to Observability section

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@
 | [Helicone](https://github.com/Helicone/helicone) | OSS LLM observability. One-line integration. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback when your AI agent config breaks it. Zero deps, single Python file. Probes health endpoint, reverts config on failure. |
 | [Weights and Biases Weave](https://wandb.ai/site/weave) | Trace and evaluate LLM apps. |
+| [OpenClaw Monitor](https://github.com/flik2002/openclaw-monitor) | Free OSS monitoring dashboard for OpenClaw AI agents. Token usage, session tracking, 7-day trends, multi-model support. Vue3 + ECharts. |
 
 ### Benchmarks
 


### PR DESCRIPTION
## OpenClaw Monitor — Monitoring Dashboard for OpenClaw AI Agents

**Repo:** [flik2002/openclaw-monitor](https://github.com/flik2002/openclaw-monitor)

A free, open-source monitoring dashboard for OpenClaw AI agents with:

- **Token usage tracking** across sessions
- **Session tracking** with detailed logs
- **7-day trend charts** via ECharts
- **Multi-model support** (Claude, GPT, Gemini, etc.)
- **Vue3** front-end, self-hosted, 100% free

| Feature | Details |
|---------|---------|
| Stars | 10 |
| License | Open Source |
| Stack | Vue3 + ECharts |
| Screenshot | [Available](https://raw.githubusercontent.com/flik2002/openclaw-monitor/main/Openclaw%20Monitor.jpg) |

---
*Submitted via GitHub Actions — maintained by @flik2002*