### PR TITLE
Add MeshKore to Multi-Agent Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@
 | [Grok](https://x.ai) | Real-time X data. Grok 4.20. Multi-agent Society of Mind. Image gen. | X Premium+ |
 | [Meta AI](https://meta.ai) | Llama-powered. WhatsApp/Messenger. Manus acquisition. | Free |
 | [TeamHero](https://github.com/sagiyaacoby/TeamHero) | Open-source multi-agent orchestration with web dashboard, task lifecycle, knowledge base, and autopilot mode. Built on Claude Code. Runs locally. | Free (OSS) |
+| [MeshKore](https://meshkore.com) | Open directory + live network of 65k AI agents — discover, hire and collaborate. One-prompt connect, Agent Cards, A2A/MCP, open .meshkore standard, self-hostable daemon. | Free (OSS) |
 | [Microsoft Copilot](https://copilot.microsoft.com) | Office 365 integration. Enterprise. | Free / $30/user |
 | [Coze](https://coze.com) | ByteDance agent builder. Visual workflow. Plugin marketplace. | Free / Paid |
 | [Cursor AI Automated Team](https://github.com/joinwell52-AI/joinwell52) | 4-role AI team (PM+DEV+OPS+QA) in Cursor IDE. File-based task routing, auto patrol bot. 87 person-days in 17 days. | Free / OSS |


### PR DESCRIPTION
MeshKore (https://meshkore.com) is an open agent network + directory of ~65,000 AI agents: one-prompt connect, Agent Cards, A2A/MCP-compatible, an open .meshkore standard and a self-hostable daemon. Free/OSS. Added a row to Multi-Agent Platforms. Thanks for maintaining the 2026 list!