### PR TITLE
Add Remio

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@
 | [Lorg](https://github.com/LorgAI/lorg-mcp-server) — Permanent intelligence archive for AI agents. Structured contributions (prompts, workflows, insights, patterns) pass an automated quality gate and are hash-chained. Trust scores are cryptographically backed and publicly auditable. Works with Claude and ChatGPT.
 | [Pathway](https://github.com/pathwaycom/pathway) | Live data RAG. Real-time streaming. 50k+ stars. |
 | [Mem0](https://github.com/mem0ai/mem0) | Memory layer for agents. Long-term across sessions. |
+| [Remio](https://remio.ai/) | Local-first AI memory and knowledge base desktop app that indexes notes, files, webpages, recordings, emails, messages, images, and other personal knowledge sources. File parsing plus local/vector indexes help agents retrieve targeted context instead of repeated grep-style scans or whole-document prompt loads. |
 | [Nex](https://github.com/nex-crm/nex-as-a-skill) | Organizational context and memory for AI agents. 60-tool MCP server, 100+ integrations. |
 | [Chroma](https://github.com/chroma-core/chroma) | OSS embedding database. Fastest way to build RAG. |
 | [Weaviate](https://github.com/weaviate/weaviate) | OSS vector DB. GraphQL. Multi-modal search. |


### PR DESCRIPTION
Adds Remio to RAG and Knowledge Bases.\n\nRemio is a local-first AI memory and knowledge base desktop app that indexes notes, files, webpages, recordings, emails, messages, images, and other personal knowledge sources. The entry highlights file parsing plus local/vector indexes for agent retrieval, reducing repeated grep-style scans and whole-document prompt loading.\n\nWebsite: https://remio.ai/