### PR TITLE
Add x402 (HTTP 402 Payments) to Protocols and Standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@
 | [Tool Use (Anthropic)](https://docs.anthropic.com/en/docs/build-with-claude/tool-use) | Claude native tool-use. Structured JSON. |
 | [OpenAPI](https://github.com/OAI/OpenAPI-Specification) | Industry-standard API spec. Foundation for agent tools. |
 | [HCS (Hashgraph Consensus Service)](https://hol.org) | Hedera open standards for agent identity (HCS-14 UAIDs), trustless P2P communication (HCS-10), and cross-protocol bridging. 187K+ verified agents. |
+| [x402 (HTTP 402 Payments)](https://github.com/coinbase/x402) | Coinbase open protocol for AI agent micropayments. Agents pay APIs in real time via HTTP 402 with on-chain stablecoin settlement on Base. Adopted by Coinbase Developer Platform. [Clawdbot by Suede Labs AI](https://suedeai.ai) ships 17 x402-gated music IP licensing endpoints as a Virtuals ACP agent. |
 
 ### Protocol Tooling
 


### PR DESCRIPTION
## Add x402 Protocol to Protocols and Standards

x402 is a growing open standard for AI agent micropayments, analogous to MCP for tool use but focused on agent-to-agent commerce. It's missing from the Protocols table alongside MCP, A2A, and HCS.

**What it is:**
- Coinbase open protocol for internet-native micropayments via HTTP 402
- Agents pay APIs in real time with on-chain stablecoin settlement on Base
- Official repo: https://github.com/coinbase/x402
- Adopted by Coinbase Developer Platform and actively promoted

**Why it belongs here:**
- MCP = tool invocation, A2A = agent coordination, **x402 = agent payments**
- These three protocols together form the agentic commerce stack
- Real-world adoption: 346+ projects at x402scan.com
- [Clawdbot by Suede Labs AI](https://suedeai.ai) ships 17 x402-gated music IP endpoints (Virtuals ACP agent on Base) — the first music IP licensing infrastructure using this protocol

The entry also mentions Clawdbot as a concrete example of x402 in the creative/media space.