### PR TITLE
Add Source Trace to Observability and Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@
 | [Helicone](https://github.com/Helicone/helicone) | OSS LLM observability. One-line integration. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback when your AI agent config breaks it. Zero deps, single Python file. Probes health endpoint, reverts config on failure. |
 | [Weights and Biases Weave](https://wandb.ai/site/weave) | Trace and evaluate LLM apps. |
+| [Source Trace](https://srctrace.com) | AI git blame: which lines came from AI and which model wrote them. Compare models using personal or team dashboard. |
 
 ### Benchmarks
 


### PR DESCRIPTION
Source Trace adds AI Git Blame, and model comparison - based on how much code is written/committed/later deleted. VS Code extension has git blame decoration, and commit history view. Both VS Code extensions and standalone CLI agents are supported: Claude, Codex, Opencode, etc.

AFAIK, this is the only tool which does AI Git Blame without git hooks/agent hooks setup. It also provides model-related metrics (for all major coding agents), with 1-click setup - friendly for solo devs or small teams.

We built Source Trace, so we can know which agent/model wrote exactly which line of code - e.g. lines 10-15 added by claude with Sonnet 4.6 model. We found that some models are producing low-quality code, so also added dashboard to show "survival rate" per model - e.g. Grok Fast writes 1000 lines, but only 500 survive to commit.

See more at https://srctrace.com/