### PR TITLE
Add Shani — open-source decision governance layer for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@
 | [Microsoft Agent Governance Toolkit](https://microsoft.com) | Runtime policy enforcement and guardrails for Azure agents. |
 | [Bifrost](https://bifrost.ai) | Real-time security enforcement in agent pipelines. |
 | [AuditOne](https://auditone.io) | Automated risk assessments and audit-ready documentation. |
+| [Shani](https://github.com/kmori-source/shani) | Open-source decision governance layer for AI agents. Signed ADO (Authorized Decision Object), HITL approval, tamper-evident audit trail. Works with LangGraph, AutoGen, nanoclaw. Apache 2.0. |
 | [EU AI Act (Official)](https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai) | Official EU AI regulatory framework. Risk tiers: Unacceptable, High-Risk, Limited, Minimal. |
 | [NIST AI RMF](https://www.nist.gov/system/files/documents/2023/01/26/AI%20RMF%201.0.pdf) | US framework. Govern, Map, Measure, Manage. |
 


### PR DESCRIPTION
## Add Shani — Decision Governance Layer for AI Agents

Shani is an open-source decision governance layer that sits between 
an AI agent's intent and execution. It issues signed ADOs (Authorized 
Decision Objects), supports HITL approval via Slack/webhook/CLI, and 
produces tamper-evident audit trails.

- Works with LangGraph, AutoGen, nanoclaw (SKILL.md-based)
- Includes CI/CD workflow: Trivy + Grype + OSV-Scanner → Shani judgment
- Apache 2.0
- GitHub: https://github.com/kmori-source/shani

Fits the AI Governance & Compliance section given the EU AI Act audit 
trail requirements.