### PR TITLE
Add Future AGI

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@
 | [Helicone](https://github.com/Helicone/helicone) | OSS LLM observability. One-line integration. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback when your AI agent config breaks it. Zero deps, single Python file. Probes health endpoint, reverts config on failure. |
 | [Weights and Biases Weave](https://wandb.ai/site/weave) | Trace and evaluate LLM apps. |
+| [Future AGI](https://github.com/future-agi/future-agi) | OSS platform for agent simulation, evaluating, tracing, guarding, and auto-improving AI agents. |
 
 ### Benchmarks
 
@@ -601,7 +602,6 @@
 - Building LLM Apps (O'Reilly) - Practical LLM application development
 - AI Agents in Action (Manning) - Production-ready AI agents
 - AI Engineering (Chip Huyen) - AI systems design and deployment
-
 ---
 
 ## 📰 Newsletters and Communities


### PR DESCRIPTION
This PR adds Future AGI to this list in the **Tracing and Monitoring** section.

[Future AGI](https://github.com/future-agi/future-agi) is an open-source (Apache-2.0), self-hostable platform for evaluating, tracing, and guardrailing LLM and AI agent apps, with 70+ eval metrics and LLM-as-judge.

The entry follows the list's existing format and placement conventions.

Disclosure: I'm affiliated with Future AGI.