### PR TITLE
Add Seedream AI Studio to Creative AI > Image Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@
 | [Leonardo AI](https://leonardo.ai) | Multi-model. Realtime Canvas. 3D gaming assets. Canva-owned. | Free / $12+/mo |
 | [Recraft](https://recraft.ai) | Design-focused. Vector art, brand consistency. | Free / Paid |
 | [InkOS](https://github.com/Narcooo/inkos) | Autonomous novel-writing CLI agent. Agents collaborate to produce long-form fiction with continuity auditing, anti-AI-slop filtering, and style cloning. | Free / OSS |
+| [Seedream AI Studio](https://seedream4.video) | Seedream 5.0/4.5/4.0 models (ByteDance). Text-to-image + image-to-video via Kling 2.1. One platform, full workflow. | Free / Paid |
 
 ### Video Generation
 


### PR DESCRIPTION
## Summary

Adds **[Seedream AI Studio](https://seedream4.video)** to the **Creative AI > Image Generation** section.

| Field | Value |
|---|---|
| Models | Seedream 5.0, 4.5, 4.0 (ByteDance family) |
| Video | One-click Kling 2.1 animation from generated images |
| Pricing | Free tier + paid plans |
| Unique value | Single platform: text→image→video workflow |

Fits alongside Midjourney, FLUX, Stable Diffusion in the image generation table. The built-in Kling 2.1 video animation also connects it to the video generation tools listed.