### PR TITLE
Add OpenClaw Monitor to Tracing and Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@
 | [Braintrust](https://braintrustdata.com) | Eval-driven development. Experiment tracking. |
 | [Arize Phoenix](https://github.com/Arize-ai/phoenix) | OSS AI observability. Traces, evals, embeddings. |
 | [Helicone](https://github.com/Helicone/helicone) | OSS LLM observability. One-line integration. |
+| [OpenClaw Monitor](https://github.com/flik2002/openclaw-monitor) | OSS monitoring dashboard for OpenClaw AI agents. Token usage, session tracking, 7-day trends, multi-model support. Vue3 + ECharts. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback when your AI agent config breaks it. Zero deps, single Python file. Probes health endpoint, reverts config on failure. |
 | [Weights and Biases Weave](https://wandb.ai/site/weave) | Trace and evaluate LLM apps. |
 


### PR DESCRIPTION
## Add OpenClaw Monitor to Tracing and Monitoring

**Repository:** [flik2002/openclaw-monitor](https://github.com/flik2002/openclaw-monitor)

A free, open-source monitoring dashboard for OpenClaw AI agents.

### Key Features

- Token usage tracking
- Session tracking  
- 7-day trends
- Multi-model support
- Vue3 + ECharts

### Justification

OpenClaw Monitor fills a gap in the OpenClaw ecosystem — it provides essential observability for AI agent deployments, complementing the tracing/monitoring tools already listed. It is the missing monitoring layer for OpenClaw agents, similar to how LangSmith/Langfuse serve LangChain users.

Placement: Tracing and Monitoring section, after Helicone.
