### PR TITLE
Add 7-24-IDE to agents list

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 
 ### IDE-Native Agents
 
+- [7-24-IDE](https://github.com/strmax195-hue/7-24-IDE) - Desktop AI coding agent. Describe what you want to build — the agent reads your files, writes code, runs commands, and shows the result.
 | Agent | Description | Pricing |
 |-------|-------------|---------|
 | [Cursor](https://cursor.com) | VS Code fork. Composer mode for multi-file edits. Claude Sonnet 5, GPT-5, Gemini 3.1. $29.3B valuation. | Free / $20/mo |

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@
 
 ### IDE-Native Agents
 
-- [7-24-IDE](https://github.com/strmax195-hue/7-24-IDE) - Desktop AI coding agent. Describe what you want to build — the agent reads your files, writes code, runs commands, and shows the result.
 | Agent | Description | Pricing |
 |-------|-------------|---------|
+| [7-24-IDE](https://github.com/strmax195-hue/7-24-IDE) | Desktop AI coding agent. Reads files, writes code, runs commands. | Open Source |
 | [Cursor](https://cursor.com) | VS Code fork. Composer mode for multi-file edits. Claude Sonnet 5, GPT-5, Gemini 3.1. $29.3B valuation. | Free / $20/mo |
 | [GitHub Copilot](https://github.com/features/copilot) | Agent Mode in VS Code. Copilot Workspace issue-to-PR. Multi-model (Claude, GPT-5.4, Gemini 3.1). | $10/mo / $39/mo Pro+ |
 | [Windsurf (Codeium)](https://windsurf.com) | Cascade agentic mode. Project-level memory. 5 parallel agents. | Free / $15/mo |


### PR DESCRIPTION
Hi there! 👋

I would like to add **7-24-IDE** to the awesome list of AI Agents for 2026.

**About the project:**
7-24-IDE is a powerful local desktop AI coding agent that seamlessly interacts with a developer's workspace. Instead of just answering questions, it acts autonomously to read files, write code, run terminal commands, and provide immediate results directly on the desktop. It fits perfectly into the IDE-native or Terminal agents categories.

**Link:** https://github.com/strmax195-hue/7-24-IDE

Thank you for reviewing and maintaining this great resource! 🚀