### PR TITLE
Add x402 protocol + Superhighway to Protocols & Standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,12 +455,14 @@
 | [Tool Use (Anthropic)](https://docs.anthropic.com/en/docs/build-with-claude/tool-use) | Claude native tool-use. Structured JSON. |
 | [OpenAPI](https://github.com/OAI/OpenAPI-Specification) | Industry-standard API spec. Foundation for agent tools. |
 | [HCS (Hashgraph Consensus Service)](https://hol.org) | Hedera open standards for agent identity (HCS-14 UAIDs), trustless P2P communication (HCS-10), and cross-protocol bridging. 187K+ verified agents. |
+| [x402 (HTTP 402 Payment Required)](https://x402.org) | Open protocol for per-call agent micropayments via USDC. Agents pay APIs autonomously — no signup, no API key, no card. Agents discover resources via the CDP Bazaar. |
 
 ### Protocol Tooling
 
 | Tool | Description |
 |------|-------------|
 | [Agentify](https://github.com/koriyoshi2041/agentify) | CLI to transform OpenAPI specs into 9 agent formats (MCP, AGENTS.md, Claude tools, etc.). `npx agentify-cli`. |
+| [Superhighway](https://superhighway.walls.sh) | Web search API for AI agents using x402 — search, news, images, scrape, and research at $0.001/call in USDC. Free API key (1k calls/month) also available. |
 
 ---
 


### PR DESCRIPTION
## What

Adds two entries to the Protocols & Standards section:

**1. x402 (HTTP 402 Payment Required)** — to the Protocols table
An open protocol for per-call micropayments via USDC, letting AI agents pay APIs autonomously without signup or API keys. The CDP Bazaar auto-catalogs x402-enabled resources. See https://x402.org.

**2. Superhighway** — to the Protocol Tooling table
A concrete x402 implementation: web search API for AI agents (search, news, images, scrape, research) at $0.001/call in USDC. Shows the protocol in action. Free API key also available for developers.

The list already covers MCP, A2A, OpenAI Function Calling, and Anthropic Tool Use — x402 closes the gap for agent payment protocols, which is increasingly relevant as autonomous agents need to pay for services without human intervention.