### PR TITLE
Add cowork-to-code-bridge to Local Execution Backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@
 
 | Tool | Description |
 |------|-------------|
-| [cowork-to-code-bridge](https://github.com/abhinaykrupa/cowork-to-code-bridge) | MCP server for Claude Code subscription as local execution backend for agents. JSONRPC 2.0 via stdio, zero network ports, token-authenticated. No API key management. Used in Crew.ai, Hermes, Open Claw. |
+| [cowork-to-code-bridge](https://github.com/abhinaykrupa/cowork-to-code-bridge) | MCP server for Claude Code subscription as local execution backend for agents. JSONRPC 2.0 via stdio, zero network ports, token-authenticated. No API key management. MIT, 496 tests, CI on macOS + Linux. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,12 @@
 | [Playwright MCP](https://github.com/microsoft/playwright-mcp) | MCP server for Playwright + AI agents. |
 | [onUI](https://github.com/onllm-dev/onUI) | OSS browser extension and MCP server for annotation-first UI pair programming with AI agents. Chrome, Edge, Firefox. Privacy-first, local only. |
 
+#### Local Execution Backends
+
+| Tool | Description |
+|------|-------------|
+| [cowork-to-code-bridge](https://github.com/abhinaykrupa/cowork-to-code-bridge) | MCP server for Claude Code subscription as local execution backend for agents. JSONRPC 2.0 via stdio, zero network ports, token-authenticated. No API key management. Used in Crew.ai, Hermes, Open Claw. |
+
 ---
 
 ## 🎙 Voice Agents


### PR DESCRIPTION
## Summary

Adding cowork-to-code-bridge as a new entry under "Developer Infrastructure → Local Execution Backends" for MCP-based local code execution.

## Entry

**cowork-to-code-bridge** — MCP server for Claude Code subscription as local execution backend for agents. JSONRPC 2.0 via stdio, zero network ports, token-authenticated. No API key management. Used in Crew.ai, Hermes, Open Claw.

## Why this matters

Agent frameworks increasingly need local code execution without separate API billing or cloud dependencies. This bridge enables agents to escalate code tasks to Claude Code running on the user's machine using their existing subscription.

Production-ready: 570 lines, 9 unit tests, live integrations.