### PR TITLE
Add OpenClacky to Terminal and CLI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 | [Kilo Code](https://kilocode.ai) | Structured modes. Tighter context. | Free + API |
 | [OpenCode](https://github.com/opencode-ai/opencode) | BYOK terminal agent for Cursor refugees. | Free + API |
 | [Caliber](https://github.com/caliber-ai-org/ai-setup) | CLI that fingerprints projects and generates/syncs AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md). Scores quality. | Free + API |
+| [OpenClacky](https://openclacky.com) | Token-efficient open-source AI agent. 93.8% Prompt Cache hit rate. Skill extensions, IM integration, BYOK. | Free + API |
 
 ### Autonomous Software Engineers
 


### PR DESCRIPTION
Adding [OpenClacky](https://openclacky.com) to the Terminal and CLI Agents section.

OpenClacky is an open-source, local-first AI agent built for token efficiency. It achieves a 93.8% 7-day Prompt Cache hit rate through frozen system prompts, dual cache markers, and idle-time context compression — delivering Claude Code-class task execution at ~0.8x the cost.

Key features:
- MIT open source, runs locally, BYOK
- Supports Claude, GPT, DeepSeek, Kimi, Gemini, OpenRouter and any OpenAI-compatible API
- 16 core tools + Skill extensions (reusable agent workflow packages)
- IM integrations: Feishu, WeCom, Discord, Telegram, DingTalk
- Browser automation, scheduled tasks, long-term memory

GitHub: https://github.com/clacky-ai/open-clacky