### PR TITLE
Add Novu Connect to Protocol Tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@
 | Tool | Description |
 |------|-------------|
 | [Agentify](https://github.com/koriyoshi2041/agentify) | CLI to transform OpenAPI specs into 9 agent formats (MCP, AGENTS.md, Claude tools, etc.). `npx agentify-cli`. |
+| [Novu Connect](https://novu.co/connect) | Connect external MCP servers to your agent mid-conversation, across every messaging channel (Slack, Teams, WhatsApp), with session-level tool access. Open source. `npx novu connect`. |
 
 ---
 


### PR DESCRIPTION
Adding **Novu Connect** to Protocols and Standards > Protocol Tooling.

Novu Connect lets an AI agent connect external MCP servers mid-conversation, with in-conversation authorization and session-level tool access, across every messaging channel (Slack, Teams, WhatsApp). Fits alongside Agentify as MCP/protocol tooling. Open source, `npx novu connect`.

- Website: https://novu.co/connect
- Source: https://github.com/novuhq/novu