### PR TITLE
Add Skales to Browser and Desktop Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@
 | [Fellou](https://fellou.ai) | Transparent. Visual workflow editing. Agentic memory. | Beta |
 | [Genspark](https://genspark.ai) | 169+ on-device models. No internet required. | Free / Paid |
 | [Grok Computer](https://x.ai) | ⭐ **Upcoming** xAI desktop agent. Mouse control, app automation. | TBA |
+| [Skales](https://skales.app) | Local-first desktop agent. Set a goal, it runs autonomously in the background. No cloud, no Docker, no terminal. GDPR-friendly, files stay on device. Win/macOS/Linux/Android. | Free / BYOK |
 
 ### Developer Infrastructure
 


### PR DESCRIPTION
Adds **Skales** under *Browser and Desktop Agents → Consumer Products*.

Skales is a local-first AI desktop agent for Windows, macOS, Linux and Android. You hand it a goal and it runs autonomously in the background, with multi-agent teams (A2A), desktop and browser automation, and 15+ providers or fully offline via Ollama. No cloud, no Docker, no terminal, one-click install, and files stay on the device (GDPR-friendly) which sets it apart from the cloud agents in this section. Source-available under BSL-1.1.

Format matches the table (links to product site, Pricing column). Site: https://skales.app