### PR TITLE
Add Agentlas OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@
 | [CAMEL](https://github.com/camel-ai/camel) | Py | Role-based simulation. Collaborative reasoning. |
 | [AutoGPT](https://github.com/Significant-Gravitas/AutoGPT) | Py | Pioneer. Now full platform with visual builder. |
 | [Bernstein](https://github.com/chernistry/bernstein) | Py | Deterministic orchestrator. Parallel coding agents, test-driven verification. Zero LLM tokens on coordination. |
+| [Agentlas OS](https://github.com/agentlas-ai/Agentlas-OS) | Py | Apache-2.0 local-first environment for portable agent and team packages, cross-host orchestration, MCP/A2A, and verification gates. |
 | [AgentScope](https://github.com/modelscope/agentscope) | Py | Alibaba multi-agent framework. |
 | [MagiC](https://github.com/kienbui1995/magic) | Go/Py | Kubernetes for AI agents. Manages any agent from any framework. Routing, cost control, DAG workflows, circuit breaker. |
 | [DeerFlow](https://github.com/bytedance/deer-flow) | Py | ByteDance. No.1 GitHub Trending Feb 2026. 25k+ stars. |


### PR DESCRIPTION
## Summary

Adds Agentlas OS to the Multi-Agent Orchestration table with the canonical public repository and a factual current description.

## Verification

- Rebuilt on current main
- One README entry only
- git diff --check: passed

Disclosure: I am submitting this entry on behalf of the Agentlas project.