### PR TITLE
Add Prismix: AI status monitoring + news + MCP directory hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@
 | [Helicone](https://github.com/Helicone/helicone) | OSS LLM observability. One-line integration. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback when your AI agent config breaks it. Zero deps, single Python file. Probes health endpoint, reverts config on failure. |
 | [Weights and Biases Weave](https://wandb.ai/site/weave) | Trace and evaluate LLM apps. |
+| [Prismix](https://prismix.dev) | Real-time status monitoring for 75+ AI services (OpenAI, Anthropic, Cursor, etc.) with email/webhook alerts, AI news from 70+ sources, and MCP server directory. |
 
 ### Benchmarks
 


### PR DESCRIPTION
## What's being added

[Prismix](https://prismix.dev) — an AI hub with three pillars:

- **Status monitoring** — real-time uptime tracking for 75+ AI services (OpenAI, Anthropic, Cursor, Windsurf, etc.) with email and webhook alerts
- **AI news** — aggregated feed from 70+ sources with personalized ranking
- **MCP directory** — 500+ MCP servers with bundles, release tracking, and discovery

## Why it fits

Added to the **Tracing and Monitoring** subsection under Observability and Evaluation. Prismix is the only tool in the list focused specifically on monitoring the *availability and status* of AI services themselves, rather than LLM traces or evals — a distinct and practically useful category for anyone building on top of AI APIs.

## Entry format

Matches the existing pipe-table style used throughout the section.
