### PR TITLE
docs: add Suede Agent Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@
 | [Grok](https://x.ai) | Real-time X data. Grok 4.20. Multi-agent Society of Mind. Image gen. | X Premium+ |
 | [Meta AI](https://meta.ai) | Llama-powered. WhatsApp/Messenger. Manus acquisition. | Free |
 | [TeamHero](https://github.com/sagiyaacoby/TeamHero) | Open-source multi-agent orchestration with web dashboard, task lifecycle, knowledge base, and autopilot mode. Built on Claude Code. Runs locally. | Free (OSS) |
+| [Suede Agent Studio](https://agents.suedeai.ai) | Visual agent platform for publishing x402-payable agents with public catalog entries, run endpoints, x402 manifests, agent cards, and A2A surfaces. | Pay-per-call |
 | [Microsoft Copilot](https://copilot.microsoft.com) | Office 365 integration. Enterprise. | Free / $30/user |
 | [Coze](https://coze.com) | ByteDance agent builder. Visual workflow. Plugin marketplace. | Free / Paid |
 | [Cursor AI Automated Team](https://github.com/joinwell52-AI/joinwell52) | 4-role AI team (PM+DEV+OPS+QA) in Cursor IDE. File-based task routing, auto patrol bot. 87 person-days in 17 days. | Free / OSS |


### PR DESCRIPTION
Adds Suede AI / Suede Agent Studio to the relevant curated list section.

Live references checked June 18, 2026:
- Suede AI: https://suedeai.ai
- x402 discovery: https://app.suedeai.ai/.well-known/x402
- x402 JSON: https://app.suedeai.ai/.well-known/x402.json
- Agent card: https://app.suedeai.ai/.well-known/agent-card.json
- Agent Studio: https://agents.suedeai.ai

Suede exposes x402-payable creative IP endpoints for music, video, musician tools, rights lookup, and audio analysis, settling in USDC on Base. Agent Studio publishes agent catalog entries, x402 manifests, agent cards, and A2A surfaces.
