### PR TITLE
Add OpenRuna agent directory link

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,8 @@
 
 ---
 
+- [OpenRuna](https://www.openruna.com/hubs/ai-agents) — Graph directory of agents, tools, prompts, and benchmarks with MCP + agent enrichment network.
+
 ## 📰 Newsletters and Communities
 
 | Resource | Description |


### PR DESCRIPTION
Adds [OpenRuna AI agents hub](https://www.openruna.com/hubs/ai-agents) — graph directory of agents, tools, prompts, and benchmarks with MCP + agent enrichment network.