### PR TITLE
Add NotFair — Claude Code skills for SEO, Google Ads & Meta Ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@
 
 | Collection | Description |
 |------------|-------------|
+| [NotFair](https://github.com/nowork-studio/NotFair) | Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads. Connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. ~2.9k stars. MIT. |
 | [OpenClaw Agent Templates](https://github.com/mergisi/awesome-openclaw-agents) | 177 production-ready SOUL.md configs across 24 categories (PM, SEO, DevOps, Writer, Support). Copy-paste ready for [OpenClaw](https://github.com/openclaw/openclaw). Visual deploy via [CrewClaw](https://crewclaw.com). |
 
 ---


### PR DESCRIPTION
Thanks for maintaining this list — it's a great reference for the AI agents ecosystem.

I'd like to add [NotFair](https://github.com/nowork-studio/NotFair), an open-source set of Claude Code skills for marketing work. It covers SEO/GEO analysis, keyword research, meta tags, schema markup, Google Ads audits, and Meta Ads (Facebook + Instagram) analysis. It connects to live data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. The project has around ~2.9k stars and is MIT licensed.

I added it to the **Agent Templates** section alongside OpenClaw Agent Templates, since both are collections of ready-to-use agent skills. Happy to move it to a different section or adjust the wording if you prefer.