### PR TITLE
Add AiToolsObserver to Newsletters and Communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,6 +608,7 @@
 
 | Resource | Description |
 |----------|-------------|
+| [AiToolsObserver](https://aitoolsobserver.com) | AI agent discovery, comparisons, ecosystem trends, and practical use cases |
 | [Awesome Agents Newsletter](https://awesomeagents.ai) | Weekly tools + reviews |
 | [aibtc.news](https://aibtc.news) | Bitcoin-focused agent news platform with bounties and classifieds. |
 | [Latent Space](https://www.latent.space/) | AI engineering podcast (Swyx + Alessio) |


### PR DESCRIPTION
## What changed

Adds AiToolsObserver to **Newsletters and Communities**.

AiToolsObserver provides AI agent discovery, comparisons, ecosystem trend coverage, and practical use cases through an actively maintained public platform.

## Disclosure

I am affiliated with AiToolsObserver. The table entry is concise, factual, and uses the existing section format.

## Validation

- Confirmed the official URL works
- Checked that the resource is not already listed
- Added one table row only