### PR TITLE
Add ax observability tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback for AI agent config changes. Monitors health endpoint, reverts config + restarts service on failures. Zero deps. |
 | [Braintrust](https://braintrustdata.com) | Eval-driven development. Experiment tracking. |
 | [Arize Phoenix](https://github.com/Arize-ai/phoenix) | OSS AI observability. Traces, evals, embeddings. |
+| [ax](https://github.com/Necmttn/ax) | Local-first observability and memory graph for AI coding-agent sessions, costs, tools, skills, and OTLP telemetry. |
 | [Helicone](https://github.com/Helicone/helicone) | OSS LLM observability. One-line integration. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback when your AI agent config breaks it. Zero deps, single Python file. Probes health endpoint, reverts config on failure. |
 | [Weights and Biases Weave](https://wandb.ai/site/weave) | Trace and evaluate LLM apps. |


### PR DESCRIPTION
Adds ax to the Observability and Evaluation → Tracing and Monitoring table.

Why it fits:
- ax is a local-first observability and memory graph for AI coding-agent sessions.
- It surfaces cost, tool, skill, session, and OTLP telemetry across Claude Code, Codex, OpenCode, Cursor, and Pi.
- The repo is active and maintained.

Validation:
- `git diff --check`
- Checked for duplicate ax/Necmttn entries in README and CONTRIBUTING
- Direct link check for `https://github.com/Necmttn/ax` returned HTTP 200

---

_Generated with [ax](https://github.com/Necmttn/ax)._