### PR TITLE
Add OpenClaw Monitor — token usage & session monitoring dashboard for OpenClaw AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@
 | [Braintrust](https://braintrustdata.com) | Eval-driven development. Experiment tracking. |
 | [Arize Phoenix](https://github.com/Arize-ai/phoenix) | OSS AI observability. Traces, evals, embeddings. |
 | [Helicone](https://github.com/Helicone/helicone) | OSS LLM observability. One-line integration. |
+| [OpenClaw Monitor](https://github.com/flik2002/openclaw-monitor) | Free open-source monitoring dashboard for OpenClaw AI agents — token usage, session tracking, 7-day trends, multi-model support. Vue3 + ECharts. |
 | [OpenClaw Monitor](https://github.com/flik2002/openclaw-monitor) | OSS monitoring dashboard for OpenClaw AI agents. Token usage, session tracking, 7-day trends, multi-model support. Vue3 + ECharts. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback when your AI agent config breaks it. Zero deps, single Python file. Probes health endpoint, reverts config on failure. |
 | [Weights and Biases Weave](https://wandb.ai/site/weave) | Trace and evaluate LLM apps. |

--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@
 | [Braintrust](https://braintrustdata.com) | Eval-driven development. Experiment tracking. |
 | [Arize Phoenix](https://github.com/Arize-ai/phoenix) | OSS AI observability. Traces, evals, embeddings. |
 | [Helicone](https://github.com/Helicone/helicone) | OSS LLM observability. One-line integration. |
+| [OpenClaw Monitor](https://github.com/flik2002/openclaw-monitor) | OSS monitoring dashboard for OpenClaw AI agents. Token usage, session tracking, 7-day trends, multi-model support. Vue3 + ECharts. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback when your AI agent config breaks it. Zero deps, single Python file. Probes health endpoint, reverts config on failure. |
 | [Weights and Biases Weave](https://wandb.ai/site/weave) | Trace and evaluate LLM apps. |
 


### PR DESCRIPTION
## Added: OpenClaw Monitor

**Description:** Free open-source monitoring dashboard for OpenClaw AI agents — token usage, session tracking, 7-day trends, multi-model support.

**Tech Stack:** Vue3 + ECharts, MIT License

**Screenshot:** https://raw.githubusercontent.com/flik2002/openclaw-monitor/main/Openclaw%20Monitor.jpg

---
Added to the **Observability and Evaluation → Tracing and Monitoring** section.