### PR TITLE
Add LoopTroop to Autonomous Software Engineers

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 | [SWE-Agent](https://github.com/princeton-nlp/SWE-agent) | Princeton. Resolves real GitHub issues autonomously. | Free (OSS) |
 | [OpenHands](https://github.com/All-Hands-AI/OpenHands) | OSS autonomous software engineer (ex-OpenDevin). | Free (OSS) |
 | [Grok Build (xAI)](https://x.ai) | 8 parallel agents for code gen. Multi-agent "Society of Mind" architecture. | xAI sub |
+| [LoopTroop](https://github.com/looptroop-ai/LoopTroop) | Local GUI orchestrator for AI coding agents. LLM Council plans, beads execute in isolated git worktrees, Ralph Loop retries failures with fresh context. Built on OpenCode. | Free (OSS) |
 
 ### Code Review and Security
 


### PR DESCRIPTION
## What

Adding [LoopTroop](https://github.com/looptroop-ai/LoopTroop) to the **Autonomous Software Engineers** section.

## Why it fits here

LoopTroop is a local, open-source GUI orchestrator that takes a coding ticket all the way to a merged PR, which is the same job Devin, OpenHands, and SWE-Agent do in this section. The difference is it's built for long, unattended runs: an LLM Council drafts and votes on the plan, work is split into atomic "beads" that run in isolated git worktrees, and a "Ralph Loop" retries failed beads with a fresh context window instead of continuing a polluted chat. It's built on top of OpenCode. Free and MIT licensed.

## Checklist

- [x] Entry is in alphabetical order within its section
- [x] Link is valid and points to official source
- [x] Description is concise and factual
- [x] Pricing info is current (Free, OSS)
- [x] No promotional language
