### PR TITLE
Update KinBot entry to Hivekeep (project renamed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@
 | [openclaw-starter](https://github.com/feralghost/openclaw-starter) | Fork-and-run template for 24/7 autonomous AI agents. Pre-configured SOUL.md, memory system, KANBAN, heartbeat. Start in 30 minutes. |
 | [LibreChat](https://github.com/danny-avila/LibreChat) | Self-hosted multi-model chat. All major providers. |
 | [LobeChat](https://github.com/lobehub/lobe-chat) | OSS ChatGPT/Gemini UI. Plugin system. Multi-modal. |
-| [KinBot](https://github.com/MarlBurroW/kinbot) | Self-hosted AI agent platform. Persistent memory (hybrid search + LLM re-ranking), 23+ providers (including Ollama), plugin store, mini-apps SDK, cron scheduling, 6 messaging channels. SQLite, runs on a Pi. |
+| [Hivekeep](https://github.com/MarlBurroW/hivekeep) | Self-hosted AI agent platform (formerly KinBot). Run a team of specialized agents with persistent memory (hybrid search + LLM re-ranking), 23+ providers (including Ollama), plugin store, mini-apps SDK, cron scheduling, and messaging channels (Telegram, Slack, Discord, Matrix). Single container, Bun + SQLite, runs on a Pi. |
 | [Anything LLM](https://github.com/Mintplex-Labs/anything-llm) | All-in-one AI app. RAG, agents. Desktop + Docker. |
 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | Data interaction with local LLM. 100% private. |
 


### PR DESCRIPTION
Disclosure: I am the author of this project.

The existing entry under Local and Self-Hosted AI > Self-Hosted Agents and UIs links to `MarlBurroW/kinbot`, which has been renamed and is now maintained at `MarlBurroW/hivekeep` (the old repo is archived). This PR updates the name, link and description to keep the list accurate.

Hivekeep is a self-hosted, MIT-licensed platform to run a team of specialized AI agents with persistent memory and a web UI; agents collaborate and build their own tools, mini-apps and plugins; reachable over Telegram, Slack, Discord and Matrix; single container (Bun + SQLite).