### PR TITLE
Add Cogito Studio to Self-Hosted Agents and UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@
 | [LibreChat](https://github.com/danny-avila/LibreChat) | Self-hosted multi-model chat. All major providers. |
 | [LobeChat](https://github.com/lobehub/lobe-chat) | OSS ChatGPT/Gemini UI. Plugin system. Multi-modal. |
 | [KinBot](https://github.com/MarlBurroW/kinbot) | Self-hosted AI agent platform. Persistent memory (hybrid search + LLM re-ranking), 23+ providers (including Ollama), plugin store, mini-apps SDK, cron scheduling, 6 messaging channels. SQLite, runs on a Pi. |
+| [Nexo](https://github.com/Nexo-Agent/nexo) | Cross-platform desktop AI workspace (Tauri + React + Rust). Multi-provider LLM, MCP integration, workspace management, local SQLite storage. |
 | [Anything LLM](https://github.com/Mintplex-Labs/anything-llm) | All-in-one AI app. RAG, agents. Desktop + Docker. |
 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | Data interaction with local LLM. 100% private. |
 

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@
 | [LibreChat](https://github.com/danny-avila/LibreChat) | Self-hosted multi-model chat. All major providers. |
 | [LobeChat](https://github.com/lobehub/lobe-chat) | OSS ChatGPT/Gemini UI. Plugin system. Multi-modal. |
 | [KinBot](https://github.com/MarlBurroW/kinbot) | Self-hosted AI agent platform. Persistent memory (hybrid search + LLM re-ranking), 23+ providers (including Ollama), plugin store, mini-apps SDK, cron scheduling, 6 messaging channels. SQLite, runs on a Pi. |
-| [Nexo](https://github.com/Nexo-Agent/nexo) | Cross-platform desktop AI workspace (Tauri + React + Rust). Multi-provider LLM, MCP integration, workspace management, local SQLite storage. |
+| [Cogito Studio](https://github.com/CogitoForge-AI/cogito-studio) | Cross-platform desktop AI workspace (Tauri + React + Rust). Multi-provider LLM, MCP integration, workspace management, local SQLite storage. |
 | [Anything LLM](https://github.com/Mintplex-Labs/anything-llm) | All-in-one AI app. RAG, agents. Desktop + Docker. |
 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | Data interaction with local LLM. 100% private. |
 


### PR DESCRIPTION
## Summary

- Adds [Cogito Studio](https://github.com/CogitoForge-AI/cogito-studio) to the **Self-Hosted Agents and UIs** section
- Cross-platform desktop AI workspace (Tauri + React + Rust) with multi-provider LLM, MCP integration, workspace management, and local SQLite storage

## Links

- GitHub: https://github.com/CogitoForge-AI/cogito-studio
- Website: https://studio.cogito-ai.org