### PR TITLE
feat: add Suede Creator Skills to Creative AI / Music section

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@
 | [ElevenLabs Music](https://elevenlabs.io) | Vocals, instrumentals. Sectional editing. Stem separation. | Plan included |
 | [Stable Audio](https://stableaudio.com) | High-quality. Commercial license. | Free / Paid |
 | [Meta AudioCraft](https://github.com/facebookresearch/audiocraft) | OSS. MusicGen + AudioGen. | Free (OSS) |
+| [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) | Open-source 21-skill agent pack for music creators: Rights Passport, Campaign in a Box, provenance mapping, royalty routing, SEO/AEO/AI EO audits, code grading, design QA, agent commerce. Runs in Claude Code / Codex. | Free (MIT) |
 
 ### 3D and Design
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@
 | [ElevenLabs Music](https://elevenlabs.io) | Vocals, instrumentals. Sectional editing. Stem separation. | Plan included |
 | [Stable Audio](https://stableaudio.com) | High-quality. Commercial license. | Free / Paid |
 | [Meta AudioCraft](https://github.com/facebookresearch/audiocraft) | OSS. MusicGen + AudioGen. | Free (OSS) |
-| [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) | Open-source 21-skill agent pack for music creators: Rights Passport, Campaign in a Box, provenance mapping, royalty routing, SEO/AEO/AI EO audits, code grading, design QA, agent commerce. Runs in Claude Code / Codex. | Free (MIT) |
+| [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) | Open-source agent skill pack for music creators: Rights Passport, Campaign in a Box, provenance mapping, royalty routing, SEO/AEO/AI EO audits, code grading, design QA, agent commerce. Runs in Claude Code / Codex. | Free (MIT) |
 
 ### 3D and Design
 


### PR DESCRIPTION
Adds [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) to the Music and Audio section — an open-source MIT-licensed 21-skill agent pack for music creators. Covers Rights Passport, Campaign in a Box, provenance mapping, royalty routing, SEO/AEO/AI EO audits, code grading, design QA, and agent commerce. Runs natively in Claude Code and Codex.