### PR TITLE
Add rust-norion

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,7 @@
 | [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) | NVIDIA. Programmable conversation guardrails. |
 | [LLM Guard](https://github.com/protectai/llm-guard) | Security toolkit. Input/output scanning. |
 | [Rebuff](https://github.com/protectai/rebuff) | Prompt injection detection. |
+| [rust-norion](https://github.com/yanghao1143/rust-norion) | Rust prototype for AI inference-control boundaries: routing, memory gates, evidence checks, rollback, and audit traces. |
 | [Lakera Guard](https://lakera.ai) | Real-time protection. Prompt injection, data leakage, toxicity. |
 | [OWASP Top 10 for Agentic Apps](https://owasp.org) | ⭐ **2026 Framework** Goal hijacking, tool misuse, cascading failure mitigations. |
 


### PR DESCRIPTION
Adds rust-norion to AI Safety and Guardrails.

Why this fits:
- open-source Rust prototype focused on runtime-control boundaries around AI/LLM systems;
- relevant controls include routing, memory gates, evidence checks, rollback, and audit traces;
- description is kept short and factual, with prototype wording.

Scope note: rust-norion is not a production inference engine or commercial gateway.