### PR TITLE
Add AI Weekly to Newsletters and Communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@
 
 | Agent | Description | Pricing |
 |-------|-------------|---------|
+| [AI Weekly](https://aiweekly.co) | Independent AI-news newsletter, 3x/week since 2015. 44,000+ professionals. The few AI stories that matter, plus the AI Weekly Index and a Who's-Who-of-AI graph. |
 | [Cursor](https://cursor.com) | VS Code fork. Composer mode for multi-file edits. Claude Sonnet 5, GPT-5, Gemini 3.1. $29.3B valuation. | Free / $20/mo |
 | [GitHub Copilot](https://github.com/features/copilot) | Agent Mode in VS Code. Copilot Workspace issue-to-PR. Multi-model (Claude, GPT-5.4, Gemini 3.1). | $10/mo / $39/mo Pro+ |
 | [Windsurf (Codeium)](https://windsurf.com) | Cascade agentic mode. Project-level memory. 5 parallel agents. | Free / $15/mo |


### PR DESCRIPTION
Adds AI Weekly (aiweekly.co) to the Newsletters and Communities section. It's an independent, solo-edited AI-news newsletter running 3x/week since 2015 with 44,000+ subscribers, in the same genre as the Rundown AI and Ben's Bites already listed here. Entry matches the existing `| [Name](URL) | Description |` table format.