### PR TITLE
Add Zara Agent - empathetic AI engineering partner (MCP, multi-agent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@
 | [RooCode](https://github.com/RooVetGit/Roo-Code) | Cline fork. Structured modes. Reduced hallucinations. | Free + API |
 | [Kilo Code](https://kilocode.ai) | Structured modes. Tighter context. | Free + API |
 | [OpenCode](https://github.com/opencode-ai/opencode) | BYOK terminal agent for Cursor refugees. | Free + API |
+| [Zara Agent](https://github.com/aldok10/zara-agent-opc) | Empathetic AI partner for OpenCode. 10 agents, cognitive memory, 132-signal skill routing, self-improving. MCP. | Free (OSS) |
 | [Caliber](https://github.com/caliber-ai-org/ai-setup) | CLI that fingerprints projects and generates/syncs AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md). Scores quality. | Free + API |
 
 ### Autonomous Software Engineers


### PR DESCRIPTION
**Zara Agent** - https://github.com/aldok10/zara-agent-opc

Empathetic AI engineering partner built on OpenCode/MCP. 10 coordinated agents, 3-layer cognitive memory, 132-signal skill routing, self-improving from outcomes.

Added to Terminal and CLI Agents section (works via OpenCode).