### PR TITLE
Add Vibe Creating to Creative AI > Video Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@
 | [Wan 2.1](https://github.com/Wan-Video/Wan2.1) | Best free OSS video gen. Self-hostable. No limits. | Free (OSS) |
 | [HunyuanVideo](https://github.com/Tencent/HunyuanVideo) | Tencent OSS. Consumer GPU. Multi-style. | Free (OSS) |
 | [LTX Video](https://github.com/Lightricks/LTX-Video) | OSS. Licensed data. Clear commercial terms. | Free (OSS) |
+| [Vibe Creating](https://github.com/Alisa0808/vibe-creating-skill) | Bilingual (EN/中文) Claude Agent Skill. Rewrites a rough idea or over-specified shot script into a model-ready text-to-video prompt for Seedance 2.0, Kling, Veo, Hailuo, Wan, Vidu. | Free (OSS) |
 
 ### Music and Audio
 


### PR DESCRIPTION
Adds **Vibe Creating** to **Creative AI → Video Generation**.

It is an open-source, MIT-licensed, bilingual (EN/中文) Claude Agent Skill that rewrites a rough idea or over-specified shot script into a clean, model-ready text-to-video prompt for the video models already listed here (Seedance 2.0, Kling, Veo, Hailuo, Wan, Vidu). It is a prompt-authoring skill rather than a video model itself, but lives in the same Creative AI / video workflow.

- Repo: https://github.com/Alisa0808/vibe-creating-skill
- Pricing: Free (OSS), MIT
- Disclosure: I am affiliated with this project.

Follows the existing 3-column table format (no promotional language). Happy to relocate if you prefer a different subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)