### PR TITLE
Add Vestige to RAG and Knowledge Bases

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@
 | [Pathway](https://github.com/pathwaycom/pathway) | Live data RAG. Real-time streaming. 50k+ stars. |
 | [Mem0](https://github.com/mem0ai/mem0) | Memory layer for agents. Long-term across sessions. |
 | [Nex](https://github.com/nex-crm/nex-as-a-skill) | Organizational context and memory for AI agents. 60-tool MCP server, 100+ integrations. |
+| [Vestige](https://github.com/samvallad33/vestige) | Local-first memory MCP server for AI coding agents. Rust, single binary. FSRS-6 retention, hybrid keyword and vector retrieval. Works with any MCP client. |
 | [Chroma](https://github.com/chroma-core/chroma) | OSS embedding database. Fastest way to build RAG. |
 | [Weaviate](https://github.com/weaviate/weaviate) | OSS vector DB. GraphQL. Multi-modal search. |
 | [Qdrant](https://github.com/qdrant/qdrant) | High-performance vector DB in Rust. |


### PR DESCRIPTION
Adds Vestige to the Data and Research Agents > RAG and Knowledge Bases section, next to the other agent-memory tools.

Vestige is a local-first memory MCP server for AI coding agents. It is written in Rust, ships as a single binary, and stores memory locally in SQLite. It uses FSRS-6 retention scheduling and hybrid keyword and vector retrieval, and speaks MCP over stdio so it works with any MCP client including Claude Code, Cursor, VS Code, and Codex.

- Repo: https://github.com/samvallad33/vestige
- npm: vestige-mcp-server (2.1.27)
- License: AGPL-3.0
- Open source, actively maintained

Follows CONTRIBUTING:
- Uses the existing two-column table format for this section
- Description is concise and factual, no promotional language
- Link points to the official source and is valid
- Single entry, one-line diff