### PR TITLE
Add Gravity to No-Code Agent Builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@
 |-------|-------------|---------|
 | [Dify](https://github.com/langgenius/dify) | OSS LLMOps. Visual agent builder. RAG. 130k+ stars. | Free / Cloud |
 | [Flowise](https://github.com/FlowiseAI/Flowise) | OSS drag-and-drop LLM agent builder. | Free (OSS) |
+| [Gravity](https://gravity.fast) | No-build AI agent platform. Describe a task in plain English and an expert-built agent returns the finished result in about 60 seconds. No setup or infrastructure. | Pay per use ($1=1k credits) |
 | [Langflow](https://github.com/langflow-ai/langflow) | Visual multi-agent and RAG builder. | Free / Cloud |
 | [Lindy](https://lindy.ai) | No-code agents. 3000+ integrations. | From $49/mo |
 | [Relevance AI](https://relevanceai.com) | No-code agents for sales, support, research. | Free / Paid |

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@
 |-------|-------------|---------|
 | [Dify](https://github.com/langgenius/dify) | OSS LLMOps. Visual agent builder. RAG. 130k+ stars. | Free / Cloud |
 | [Flowise](https://github.com/FlowiseAI/Flowise) | OSS drag-and-drop LLM agent builder. | Free (OSS) |
-| [Gravity](https://gravity.fast) | No-build AI agent platform. Describe a task in plain English and an expert-built agent returns the finished result in about 60 seconds. No setup or infrastructure. | Pay per use ($1=1k credits) |
+| [Gravity](https://gravity.fast) | No-build AI agent platform. Describe a task in plain English and an expert-built agent returns the finished result in about 60 seconds. No setup or infrastructure. | Free / from $20/mo |
 | [Langflow](https://github.com/langflow-ai/langflow) | Visual multi-agent and RAG builder. | Free / Cloud |
 | [Lindy](https://lindy.ai) | No-code agents. 3000+ integrations. | From $49/mo |
 | [Relevance AI](https://relevanceai.com) | No-code agents for sales, support, research. | Free / Paid |


### PR DESCRIPTION
Adds **Gravity** ([gravity.fast](https://gravity.fast)) under *Task and Workflow Agents → No-Code Agent Builders*.

Gravity is a no-build AI agent platform: you describe a task in plain English and an expert-built agent returns the finished result in about 60 seconds, with no setup or infrastructure. Pricing is pure pay-per-use ($1 = 1,000 credits), no subscription.

- Fits the section (no-code, task/workflow outcomes).
- Follows the existing `| [Name](link) | Description | Pricing |` format.
- Placed alphabetically between Flowise and Langflow.

Thanks for maintaining this list.