### PR TITLE
Add Marketing & SEO Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,8 +354,10 @@
 
 ### AEO & Generative Engine Optimisation
 
-- [awesome-aeo-seo-agents](https://github.com/discoveredlabs/awesome-aeo-seo-agents) - Curated list of agentic GEO/AEO frameworks, MCP servers for SEO data, agent skill packages, and autonomous content pipelines for AI search optimisation.
-- [awesome-aeo-seo](https://github.com/discoveredlabs/awesome-aeo-seo) - Research, tooling, and measurement guides for answer engine optimisation - the reference list covering what these agents are built to optimise for.
+| Resource | Description |
+|----------|-------------|
+| [awesome-aeo-seo-agents](https://github.com/discoveredlabs/awesome-aeo-seo-agents) | Agentic GEO/AEO frameworks, MCP servers for SEO data, agent skill packages, and autonomous content pipelines for AI search optimisation. |
+| [awesome-aeo-seo](https://github.com/discoveredlabs/awesome-aeo-seo) | Research, tooling, and measurement guides for answer engine optimisation. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - [Creative AI](#-creative-ai) — Image, Video, Music, 3D
 - [Task and Workflow Agents](#-task--workflow-agents) — Automation, No-Code Builders
 - [Customer Support and CRM Agents](#-customer-support--crm-agents)
+- [Marketing & SEO Agents](#-marketing--seo-agents)
 - [Data and Research Agents](#-data--research-agents) — Deep Research, Data Analysis, RAG
 - [Local and Self-Hosted AI](#-local--self-hosted-ai) — LLM Runners, Self-Hosted UIs
 - [Multi-Agent Platforms](#-multi-agent-platforms)
@@ -346,6 +347,15 @@
 | [Instantly](https://instantly.ai) | AI cold email. Unlimited accounts. Smart rotation. | From $30/mo |
 | [Overloop CLI](https://github.com/sortlist/overloop-cli) | AI outbound CLI. Source 450M+ contacts, email + LinkedIn campaigns, conversations. Agent-native JSON output. | $69-99/mo |
 | [Lavender](https://lavender.ai) | AI email coach. Real-time scoring. | Free / $29/mo |
+
+---
+
+## 📈 Marketing & SEO Agents
+
+### AEO & Generative Engine Optimisation
+
+- [awesome-aeo-seo-agents](https://github.com/discoveredlabs/awesome-aeo-seo-agents) - Curated list of agentic GEO/AEO frameworks, MCP servers for SEO data, agent skill packages, and autonomous content pipelines for AI search optimisation.
+- [awesome-aeo-seo](https://github.com/discoveredlabs/awesome-aeo-seo) - Research, tooling, and measurement guides for answer engine optimisation - the reference list covering what these agents are built to optimise for.
 
 ---
 


### PR DESCRIPTION
Hey - noticed you've got 20+ agent categories but nothing for marketing/SEO yet. It's one of the higher-adoption agentic use cases right now so seemed worth adding.

Added a new "📈 Marketing & SEO Agents" section with awesome-aeo-seo-agents as the anchor resource - covers agentic GEO/AEO frameworks, MCP servers for SEO data, agent skill packages, and autonomous content optimisation pipelines.

All maintained by myself at Discovered. Happy to expand the section with more individual tools if that'd be useful.

**Alternatively, if individual links fit the repo better, these are the most relevant from our work:**

- [Agentic Browsing Checker](https://discoveredlabs.com/tools/agentic-browsing-checker) - free tool running 19 OPERABLE framework checks: WebMCP registration, form annotation, accessibility tree quality, llms.txt validation, ARIA live regions, keyboard operability, and AI crawler robots.txt access - tells you whether a site is actually usable by AI agents
- [AI Assist Widget](https://discoveredlabs.com/tools/ai-assist-widget) - free single script tag adding a floating button bar that opens ChatGPT, Claude, Perplexity, Grok, or Gemini with the current page pre-filled; useful for sites wanting to expose themselves to AI agents with zero infrastructure
- [How Gemini Works: AI Agent Architecture Deep Dive](https://discoveredlabs.com/blog/how-gemini-works-ai-agent-architecture-deepdive) - reverse-engineered Gemini's session architecture: 227 RPC calls, 138 feature flags, 6 routing modes including Agent and Deep Research modes
- [AI Visibility Tracker](https://discoveredlabs.com/technology/ai-visibility-tracker) - tracks brand citations across ChatGPT, Claude, Perplexity, Google AI Overviews, and Gemini; useful context for teams building agents that need to surface specific brands or content