### PR TITLE
Add CloudAxis to Browser Developer Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@
 | [Plasmate](https://github.com/plasmate-labs/plasmate) | Headless browser compiling HTML to structured JSON (SOM). 17.5x compression, 13 MCP tools. First browser tool on MCP Registry. Rust, Apache-2.0. |
 | [Playwright MCP](https://github.com/microsoft/playwright-mcp) | MCP server for Playwright + AI agents. |
 | [onUI](https://github.com/onllm-dev/onUI) | OSS browser extension and MCP server for annotation-first UI pair programming with AI agents. Chrome, Edge, Firefox. Privacy-first, local only. |
+| [CloudAxis](https://cloudaxis.ai) | Managed cloud workspace with a persistent desktop, real browser (Playwright/CDP), cron-scheduled jobs, multi-agent workflows, and hosted LLM access. Free tier available. |
 
 ---
 


### PR DESCRIPTION
Added [CloudAxis](https://cloudaxis.ai) to the **Developer Infrastructure** table under Browser and Desktop Agents.

CloudAxis provides a managed cloud workspace with a persistent desktop, real browser (Playwright/CDP-accessible), cron-scheduled jobs, multi-agent workflows, and hosted LLMs. It sits closest to Browserbase/Airtop in function -- cloud browser infrastructure -- but bundles the full agent runtime and scheduling layer on top.

Free tier: 100 AI credits, 30 browser minutes, 2 scheduled jobs/month.
Pricing page: https://cloudaxis.ai/#pricing