### PR TITLE
Add Talon to Self-Hosted Agents and UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@
 | [KinBot](https://github.com/MarlBurroW/kinbot) | Self-hosted AI agent platform. Persistent memory (hybrid search + LLM re-ranking), 23+ providers (including Ollama), plugin store, mini-apps SDK, cron scheduling, 6 messaging channels. SQLite, runs on a Pi. |
 | [Anything LLM](https://github.com/Mintplex-Labs/anything-llm) | All-in-one AI app. RAG, agents. Desktop + Docker. |
 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | Data interaction with local LLM. 100% private. |
+| [Talon](https://github.com/dylanneve1/talon) | Self-hosted agent across Telegram, Discord, Teams & terminal. Pluggable backends (Claude, OpenAI, Codex, Kilo, OpenCode), full MCP tools, always-on heartbeat + goals + dream agents, long-term memory palace. MIT, TypeScript. |
 
 ---
 


### PR DESCRIPTION
Adding **[Talon](https://github.com/dylanneve1/talon)** to **Local and Self-Hosted AI → Self-Hosted Agents and UIs**, alongside OpenClaw and KinBot.

Talon is an open-source (MIT, TypeScript) self-hosted harness that runs one persistent AI agent across Telegram, Discord, Teams, and the terminal, with pluggable backends (Claude, OpenAI Agents, Codex, Kilo, OpenCode), full MCP tool access, always-on background agents (heartbeat, goals, dream), and a long-term memory palace. Single table row, formatted to match the section. Thanks for the list!