### PR TITLE
Add Nimbalyst to the list of agents in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 | [Sourcegraph Cody](https://sourcegraph.com/cody) | Excels at large codebases. Enterprise context engine. | Free / $9/mo |
 | [Google Antigravity](https://idx.google.com) | Free Claude Opus 4.6 access. Learning-focused. | Free |
 | [Kiro](https://kiro.dev) | Spec-driven development. Write specs → auto-generate tasks → implement. DevOps automation. | Free beta |
+| [Nimbalyst](https://github.com/nimbalyst/nimbalyst) | Open-source visual workspace. Run agents → review changes as diffs → track tasks. Build with Codex, Claude Code, and more. | Free, open-source |
 
 ### Terminal and CLI Agents
 


### PR DESCRIPTION
Nimbalyst is open source, visual workspace, like a Kiro or AntiGravity