### PR TITLE
Add Project Telos protocol tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@
 | Tool | Description |
 |------|-------------|
 | [Agentify](https://github.com/koriyoshi2041/agentify) | CLI to transform OpenAPI specs into 9 agent formats (MCP, AGENTS.md, Claude tools, etc.). `npx agentify-cli`. |
+| [Project Telos](https://github.com/HarperZ9/telos) | Local-first MCP/CLI workbench for agent workflows: source provenance, workspace maps, routing ledgers, action receipts, context packs, and verification doctors. |
 
 ---
 


### PR DESCRIPTION
Adds Project Telos to this AI agents protocol tooling list as a local-first MCP/CLI workbench for inspectable AI-assisted development and operations.

Project Telos exposes source-checkout MCP surfaces and local verification workflows for source provenance, workspace maps, routing ledgers, action receipts, context packs, CI/operator doctors, and MATCH/DRIFT/UNVERIFIABLE review packets.

Validation:
- git diff --check
- rg Project Telos / HarperZ9/telos in README.md
- Native Telos operator doctor in this outreach session reports MATCH, 14/14 checks, and 70 available MCP tools across Gather, Index, Forum, Crucible, and Telos.
