### PR TITLE
Add qq-ai-bot to Self-Hosted Agents and UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@
 | [KinBot](https://github.com/MarlBurroW/kinbot) | Self-hosted AI agent platform. Persistent memory (hybrid search + LLM re-ranking), 23+ providers (including Ollama), plugin store, mini-apps SDK, cron scheduling, 6 messaging channels. SQLite, runs on a Pi. |
 | [Anything LLM](https://github.com/Mintplex-Labs/anything-llm) | All-in-one AI app. RAG, agents. Desktop + Docker. |
 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | Data interaction with local LLM. 100% private. |
+| [qq-ai-bot](https://github.com/happysnaker/qq-ai-bot) | Self-hosted QQ ↔ AI bridge for OneBot 11 / NapCat / LLOneBot. Bridges ACP-compatible local agents with persistent sessions, progress streaming, and a Docker demo. |
 
 ---
 


### PR DESCRIPTION
## Summary
- add `qq-ai-bot` under **Self-Hosted Agents and UIs**
- position it as a self-hosted QQ / OneBot bridge for ACP-compatible local agents

## Why this fits
`qq-ai-bot` is not just a chat UI: it is a deployable self-hosted messaging bridge that connects OneBot 11 / NapCat / LLOneBot transport with ACP-compatible local agents. The public repo already documents persistent sessions, progress streaming, and a Docker demo, so it fits the self-hosted agent surface area in this list.