### PR TITLE
Add AVA to Open-Source Voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@
 
 | Tool | Description |
 |------|-------------|
+| [AVA](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk) | OSS AI voice agent for Asterisk/FreePBX. Mix STT/LLM/TTS providers or run fully local. |
 | [LiveKit Agents](https://github.com/livekit/agents) | OSS real-time voice/video AI agents. |
 | [Rasa](https://github.com/RasaHQ/rasa) | OSS conversational AI. Self-hosted. NLU training. |
 | [Pipecat](https://github.com/pipecat-ai/pipecat) | OSS voice and multimodal conversational AI. |


### PR DESCRIPTION
Adds AVA to the **Open-Source Voice** section — an open-source, self-hosted AI voice agent for Asterisk/FreePBX. It fits alongside LiveKit Agents, Pipecat and Vocode as an OSS voice-agent stack.

- [x] Entry is alphabetical within its section (AVA placed first)
- [x] Link points to the official source repo
- [x] Description is concise and factual
- [x] No promotional language

Repo: https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk (MIT, actively maintained)
Live demo: https://demo.agent6789.com