### PR TITLE
Add Superdense to RAG and Knowledge Bases

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@
 | [Pathway](https://github.com/pathwaycom/pathway) | Live data RAG. Real-time streaming. 50k+ stars. |
 | [Mem0](https://github.com/mem0ai/mem0) | Memory layer for agents. Long-term across sessions. |
 | [Nex](https://github.com/nex-crm/nex-as-a-skill) | Organizational context and memory for AI agents. 60-tool MCP server, 100+ integrations. |
+| [Superdense](https://github.com/Nimrobo/superdense) | Local outcome-loop + reward layer for coding agents. Long-term memory across sessions — remembers what worked, records hypotheses/experiments, measures how each change landed. No cloud. |
 | [Chroma](https://github.com/chroma-core/chroma) | OSS embedding database. Fastest way to build RAG. |
 | [Weaviate](https://github.com/weaviate/weaviate) | OSS vector DB. GraphQL. Multi-modal search. |
 | [Qdrant](https://github.com/qdrant/qdrant) | High-performance vector DB in Rust. |


### PR DESCRIPTION
Adds [Superdense](https://github.com/Nimrobo/superdense) to the RAG and Knowledge Bases table, alongside Mem0 and Nex — it's a long-term memory layer for coding agents (records session/artifact history, hypotheses, experiments, and reward snapshots across runs), not a vector DB or RAG pipeline.

- npm package: `@nimrobo/superdense`
- Local-only, no cloud
- Docs: https://nimroboai.com

Kept the single-line table format consistent with the surrounding entries and alphabetical order within the table.