### PR TITLE
Add AgentServices to Protocol Tooling — x402 paid APIs for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@
 | Tool | Description |
 |------|-------------|
 | [Agentify](https://github.com/koriyoshi2041/agentify) | CLI to transform OpenAPI specs into 9 agent formats (MCP, AGENTS.md, Claude tools, etc.). `npx agentify-cli`. |
+| [AIServices](https://github.com/vbkotecha/aiservices-api) | Paid APIs for AI agents. 21 endpoints (crypto data, DeFi yields, dispute resolution) with x402 micropayments. MCP-compatible. |
 
 ---
 


### PR DESCRIPTION
## AgentServices — Paid APIs for AI Agents

Added to the **Protocol Tooling** table. AgentServices provides 21 API endpoints for AI agents with x402 micropayments (USDC on Base) and MCP compatibility.

- 21 endpoints: crypto data, DeFi yields, market indicators, fear-greed, dispute resolution
- x402 payments: agents pay per-call (bash.01-bash.05) with USDC on Base L2
- MCP server at /mcp (SSE transport, 37 MCP tools)
- Dispute resolution with 7 policy templates for agent commerce

**Links**: [GitHub](https://github.com/vbkotecha/aiservices-api) | [API](https://agentservices.to)