### PR TITLE
feat: add VeraData to AI Governance, x402 protocol to Protocols & Standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,7 @@
 | [OpenAI Function Calling](https://platform.openai.com/docs/guides/function-calling) | OpenAI native tool-use. JSON schema. |
 | [Tool Use (Anthropic)](https://docs.anthropic.com/en/docs/build-with-claude/tool-use) | Claude native tool-use. Structured JSON. |
 | [OpenAPI](https://github.com/OAI/OpenAPI-Specification) | Industry-standard API spec. Foundation for agent tools. |
+| [x402](https://github.com/x402-foundation/x402) | ⭐ **New in 2026** — HTTP payment protocol for AI agents. Agents pay per API call in USDC via EIP-3009. Zero subscriptions. Implemented by [VeraData](https://api.veradata.dev) (compliance) and [Intelica](https://api.intelica.dev) (intelligence). |
 | [HCS (Hashgraph Consensus Service)](https://hol.org) | Hedera open standards for agent identity (HCS-14 UAIDs), trustless P2P communication (HCS-10), and cross-protocol bridging. 187K+ verified agents. |
 
 ### Protocol Tooling
@@ -539,6 +540,7 @@
 | [Microsoft Agent Governance Toolkit](https://microsoft.com) | Runtime policy enforcement and guardrails for Azure agents. |
 | [Bifrost](https://bifrost.ai) | Real-time security enforcement in agent pipelines. |
 | [AuditOne](https://auditone.io) | Automated risk assessments and audit-ready documentation. |
+| [VeraData](https://api.veradata.dev) | LATAM compliance API: sanctions screening (OFAC+UN+EU+UK, 59k+ entries), KYB for CO/MX/BR/CL/PE with EU AI Act Art.12/13 audit trail. MCP-native, x402 micropayments. |
 | [EU AI Act (Official)](https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai) | Official EU AI regulatory framework. Risk tiers: Unacceptable, High-Risk, Limited, Minimal. |
 | [NIST AI RMF](https://www.nist.gov/system/files/documents/2023/01/26/AI%20RMF%201.0.pdf) | US framework. Govern, Map, Measure, Manage. |
 


### PR DESCRIPTION
## Summary

Two additions that strengthen compliance and payments protocol coverage:

### 1. VeraData → AI Governance and Compliance

With EU AI Act full obligations taking effect **August 2, 2026**, VeraData is the only MCP-native compliance API covering LATAM:
- Sanctions: OFAC SDN + UN + EU + UK HM Treasury (59,454 entries)
- KYB for CO/MX/BR/CL/PE — business registry + sanctions + risk narrative
- **EU AI Act Art.12/13** immutable audit trail — every AI decision logged with SHA-256 hash chain
- MCP: `https://api.veradata.dev/mcp` | x402 micropayments ($0.01–$0.15 USDC) | Trial: `X-TRIAL: true`

### 2. x402 → Protocols and Standards

x402 is an emerging HTTP payment protocol (2025–2026) letting AI agents pay per API call in USDC — no subscriptions, no API keys. Growing alongside MCP and A2A. Live implementations: VeraData (compliance) and Intelica (competitive intelligence).

## Format
- Follows existing table format in both sections
- All links verified active