### PR TITLE
Add rtblint to Protocol Tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@
 | Tool | Description |
 |------|-------------|
 | [Agentify](https://github.com/koriyoshi2041/agentify) | CLI to transform OpenAPI specs into 9 agent formats (MCP, AGENTS.md, Claude tools, etc.). `npx agentify-cli`. |
+| [rtblint](https://github.com/aleksUIX/rtblint) | Rust CLI, WASM browser tester, and MCP server that validates OpenRTB bid requests against the IAB Tech Lab spec (2.0 through 3.0): missing fields, type mismatches, deprecated/unknown fields. Free, open source (Apache 2.0). ![Stars](https://img.shields.io/github/stars/aleksUIX/rtblint) |
 
 ---
 


### PR DESCRIPTION
Adds rtblint (https://github.com/aleksUIX/rtblint) to Protocol Tooling, next to Agentify since both are CLI-first tools for working with agent-facing API specs.

rtblint is an OpenRTB bid request validator/linter: it checks a bid request against the IAB Tech Lab OpenRTB spec (2.0 through 3.0) for malformed JSON, missing fields, unknown/deprecated fields, and type mismatches. It ships as a Rust CLI, a WASM browser tester, and an MCP server so agents can call the same validation.

Note on the table format: the Protocol Tooling table in this section is two columns (Tool, Description), not the four-column Name/Description/Pricing/Stars format in CONTRIBUTING.md, so I matched the existing table and folded the pricing note and a live shields.io stars badge into the description cell instead of adding new columns.

Apache 2.0, actively developed (about 2 months old, daily commits).

Disclosure: rtblint is my project.