### PR TITLE
Add Proliferate to Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@
 | [RooCode](https://github.com/RooVetGit/Roo-Code) | Cline fork. Structured modes. Reduced hallucinations. | Free + API |
 | [Kilo Code](https://kilocode.ai) | Structured modes. Tighter context. | Free + API |
 | [OpenCode](https://github.com/opencode-ai/opencode) | BYOK terminal agent for Cursor refugees. | Free + API |
+| [Proliferate](https://proliferate.com) | Open-source local and cloud agent IDE. Parallel workspaces, subagents, plugins, MCP, review flows. | Free (OSS) |
 | [Caliber](https://github.com/caliber-ai-org/ai-setup) | CLI that fingerprints projects and generates/syncs AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md). Scores quality. | Free + API |
 
 ### Autonomous Software Engineers


### PR DESCRIPTION
Adds Proliferate to the Coding Agents section.

Why it fits:
- open-source local and cloud agent IDE
- designed for coding-agent workflows with parallel workspaces, subagents, plugins, and MCP
- currently public and actively maintained

Source:
- https://github.com/proliferate-ai/proliferate
- https://proliferate.com/docs