### PR TITLE
Add Tree Ring Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@
 | [Lorg](https://github.com/LorgAI/lorg-mcp-server) — Permanent intelligence archive for AI agents. Structured contributions (prompts, workflows, insights, patterns) pass an automated quality gate and are hash-chained. Trust scores are cryptographically backed and publicly auditable. Works with Claude and ChatGPT.
 | [Pathway](https://github.com/pathwaycom/pathway) | Live data RAG. Real-time streaming. 50k+ stars. |
 | [Mem0](https://github.com/mem0ai/mem0) | Memory layer for agents. Long-term across sessions. |
+| [Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory) | Local-first Rust CLI/TUI for AI agent memory lifecycle: recall, audit, forgetting, consolidation, and JSON export. |
 | [Nex](https://github.com/nex-crm/nex-as-a-skill) | Organizational context and memory for AI agents. 60-tool MCP server, 100+ integrations. |
 | [Chroma](https://github.com/chroma-core/chroma) | OSS embedding database. Fastest way to build RAG. |
 | [Weaviate](https://github.com/weaviate/weaviate) | OSS vector DB. GraphQL. Multi-modal search. |


### PR DESCRIPTION
## Summary
- Adds Tree Ring Memory to the RAG and Knowledge Bases section.
- Describes it as a local-first Rust CLI/TUI for AI agent memory lifecycle: recall, audit, forgetting, consolidation, and JSON export.

## Validation
- `git diff --check`
- Confirmed the Tree Ring Memory entry appears once in README.md
- Confirmed the project link returns HTTP 200