### PR TITLE
Add iris to Tracing and Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@
 | [Helicone](https://github.com/Helicone/helicone) | OSS LLM observability. One-line integration. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback when your AI agent config breaks it. Zero deps, single Python file. Probes health endpoint, reverts config on failure. |
 | [Weights and Biases Weave](https://wandb.ai/site/weave) | Trace and evaluate LLM apps. |
+| [iris](https://github.com/itzenata/iris-tui) | OSS live TUI supervisor for Claude Code sessions. Status, tokens, cost, one-pane approvals. |
 
 ### Benchmarks
 


### PR DESCRIPTION
Adds [iris](https://github.com/itzenata/iris-tui) — an open-source live terminal supervisor for every active Claude Code session: per-session status, model, tokens, estimated cost (with an aggregate counter), live activity feed, and one-pane approve/deny of pending tool calls via a PreToolUse hook. Local-first and read-only over session transcripts; no telemetry.

Rust + ratatui, MIT, on crates.io as [iris-tui](https://crates.io/crates/iris-tui).