### PR TITLE
Add LiveContext to Task and Workflow Agents (Automation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@
 | [Activepieces](https://github.com/activepieces/activepieces) | OSS Zapier alternative with AI. | Free (OSS) |
 | [Temporal](https://github.com/temporalio/temporal) | Durable execution for long-running agent workflows. | Free / Cloud |
 | [Mission Control](https://github.com/MeisnerDan/mission-control) | Cockpit for the agentic era — manage AI agent swarms with autonomous daemon, Field Ops for real-world execution, and approval workflows. | Free (OSS) |
+| [LiveContext](https://github.com/livecontext-ai/livecontext-ce) | Self-hosted AI automation. Describe a job in chat, get a readable workflow with scoped, budgeted AI agents, and a shipped app. Fair-code. | Free / Cloud |
 
 ### No-Code Agent Builders
 


### PR DESCRIPTION
Adds **LiveContext** to the Task and Workflow Agents > Automation table.

LiveContext is a self-hosted AI automation platform: describe a job in chat and it builds a workflow you can read, runs it with AI agents that are scoped and budgeted (not a black box), and ships it as a small app. Fair-code (Sustainable Use License, like n8n), self-hostable with one docker compose up.

- Site: https://livecontext.ai
- Repo: https://github.com/livecontext-ai/livecontext-ce

Thanks for maintaining this list!