### PR TITLE
Add Stock Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@
 | [Hex AI](https://hex.tech) | Collaborative data platform. AI analysis. | Free / Paid |
 | [PandasAI](https://github.com/Sinaptik-AI/pandas-ai) | Chat with your data. NL to Pandas/SQL. | Free (OSS) |
 | [Signals CLI](https://github.com/sortlist/signals-cli) | Intent signal CLI. LinkedIn engagers, keyword posters, job changers, funding events. JSON output for agent pipelines. | Paid |
+| [Stock Analysis](https://github.com/AdvancingTitans/stock-analysis) | Evidence-driven market recap CLI for A/HK/US stocks and funds. Emits Markdown reports and JSON Evidence Packs for agent workflows. | Free (OSS) |
 | [TaskWeaver](https://github.com/microsoft/TaskWeaver) | Microsoft. Code-first data analytics agents. | Free (OSS) |
 | [AI for Database](https://aifordatabase.com) | Connect to any database in plain English. NL queries, self-refreshing dashboards, automated workflows triggered by data changes. | Freemium |
 


### PR DESCRIPTION
Adds Stock Analysis to Data and Research Agents. It is an open-source CLI for evidence-driven A/HK/US stock and fund recaps, with Markdown reports and JSON Evidence Packs for agent workflows.