### PR TITLE
Add LLMGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@
 | [Flowise](https://github.com/FlowiseAI/Flowise) | OSS drag-and-drop LLM agent builder. | Free (OSS) |
 | [Langflow](https://github.com/langflow-ai/langflow) | Visual multi-agent and RAG builder. | Free / Cloud |
 | [Lindy](https://lindy.ai) | No-code agents. 3000+ integrations. | From $49/mo |
+| [LLMGraph](https://llmgraph.ai) | Visual builder for LLM/AI workflows. Turn docs and models into RAG chatbots and agents, then deploy each to a REST API and an embeddable chat widget. | 14-day trial / Paid |
 | [Relevance AI](https://relevanceai.com) | No-code agents for sales, support, research. | Free / Paid |
 | [Rivet](https://rivet.ironcladapp.com) | Visual AI workflow builder. Drag-and-drop. | Free (OSS) |
 | [FastAgency](https://github.com/airtai/fastagency) | Deploy multi-agent workflows as APIs. | Free (OSS) |


### PR DESCRIPTION
Adds **LLMGraph** (https://llmgraph.ai) to **Task and Workflow Agents → No-Code Agent Builders**, alongside Dify, Flowise, Langflow, and Lindy.

LLMGraph is a visual builder for LLM/AI workflows: turn docs and models into RAG chatbots and agents, then deploy each to a REST API and an embeddable chat widget.

Per CONTRIBUTING.md: entry is in alphabetical order within the section (between Lindy and Relevance AI), uses the section's `| [Name](link) | Description | Pricing |` table format, links to the official source, factual/non-promotional description, and current pricing (14-day trial / Paid). Publicly available (released) tool; no duplicate entry.