### PR TITLE
Add Nanocoder to Terminal and CLI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@
 | [RooCode](https://github.com/RooVetGit/Roo-Code) | Cline fork. Structured modes. Reduced hallucinations. | Free + API |
 | [Kilo Code](https://kilocode.ai) | Structured modes. Tighter context. | Free + API |
 | [OpenCode](https://github.com/opencode-ai/opencode) | BYOK terminal agent for Cursor refugees. | Free + API |
+| [Nanocoder](https://github.com/Nano-Collective/nanocoder) | Local-first OSS terminal agent built by a community collective. Bring your own model (Ollama, OpenRouter, any OpenAI-compatible API). MCP support. | Free + API |
 | [Caliber](https://github.com/caliber-ai-org/ai-setup) | CLI that fingerprints projects and generates/syncs AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md). Scores quality. | Free + API |
 
 ### Autonomous Software Engineers

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@
 | [RooCode](https://github.com/RooVetGit/Roo-Code) | Cline fork. Structured modes. Reduced hallucinations. | Free + API |
 | [Kilo Code](https://kilocode.ai) | Structured modes. Tighter context. | Free + API |
 | [OpenCode](https://github.com/opencode-ai/opencode) | BYOK terminal agent for Cursor refugees. | Free + API |
-| [Nanocoder](https://github.com/Nano-Collective/nanocoder) | Local-first OSS terminal agent built by a community collective. Bring your own model (Ollama, OpenRouter, any OpenAI-compatible API). MCP support. | Free + API |
 | [Caliber](https://github.com/caliber-ai-org/ai-setup) | CLI that fingerprints projects and generates/syncs AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md). Scores quality. | Free + API |
+| [Nanocoder](https://github.com/Nano-Collective/nanocoder) | Local-first OSS terminal agent built by a community collective. Bring your own model (Ollama, OpenRouter, any OpenAI-compatible API). MCP support. | Free + API |
 
 ### Autonomous Software Engineers
 


### PR DESCRIPTION
Adds [Nanocoder](https://github.com/Nano-Collective/nanocoder) to the **Terminal and CLI Agents** section.

Nanocoder is a local-first, open-source terminal coding agent built by a community collective. It's provider-agnostic (Ollama, OpenRouter, or any OpenAI-compatible API), keeps code on your machine, and supports MCP.

### PR Requirements
- [x] Entry added in the appropriate section
- [x] Link is valid and points to the official source
- [x] Description is concise and factual
- [x] Pricing info is current (Free + API)
- [x] No promotional language