### PR TITLE
Add Doubleword Control Layer to Local LLM Runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@
 | [LM Studio](https://lmstudio.ai) | Desktop app for local LLMs. Beautiful UI. All platforms. |
 | [Jan](https://github.com/janhq/jan) | OSS ChatGPT alternative. 100% offline. |
 | [LocalAI](https://github.com/mudler/LocalAI) | Drop-in OpenAI API replacement. No GPU required. |
+| [Control Layer](https://github.com/doublewordai/control-layer) | OSS AI model gateway (Rust). Unified OpenAI-compatible API across providers. Auth, API keys, user management, request logging. Self-hosted. |
 | [Cerebras Inference](https://inference.cerebras.ai) | Fastest LLM inference. Llama 3.3 70B at 1000+ tok/s. Free tier. |
 | [Groq Cloud](https://console.groq.com) | Ultra-fast LPU inference. Mixtral, Llama, Gemma. Free API tier. |
 | [Fireworks AI](https://fireworks.ai) | Serverless LLM inference. Fine-tuning. RAG. Free credits. |


### PR DESCRIPTION
## Add: Control Layer (Doubleword)

Adds one new entry to **Local and Self-Hosted AI → Local LLM Runners**.

| [Control Layer](https://github.com/doublewordai/control-layer) | OSS AI model gateway (Rust). Unified OpenAI-compatible API across providers. Auth, API keys, user management, request logging. Self-hosted. |

**Why it belongs:** Control Layer is an open-source (Apache-2.0), actively maintained self-hostable AI model gateway — infrastructure that routes and secures inference across model providers behind one OpenAI-compatible endpoint. It sits alongside the other self-hosted inference/serving infra in this section.

### PR checklist
- [x] Link is valid and points to the official source (GitHub repo)
- [x] Description is concise and factual — no promotional language
- [x] Single entry, matches the 2-column `| Tool | Description |` table format of the section
- [x] Actively maintained, publicly available, open-source

Note: the Local LLM Runners table is ordered by curation rather than strict alphabetical order, so I placed this next to the other self-hosted, OpenAI-compatible tools (LocalAI). Happy to move it if you'd prefer a different spot.