### PR TITLE
Add DevIntern to Autonomous Software Engineers

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@
 | Agent | Description | Pricing |
 |-------|-------------|---------|
 | [Devin](https://devin.ai) | Cognition. Fully autonomous. Sandboxed cloud env. Devin 2.0 with Interactive Planning. | $20/mo + ACU |
+| [DevIntern](https://devintern.com) | Turns tickets from Jira, Linear, Trello, Asana, Azure DevOps, GitHub Issues, or markdown into self-reviewed PRs using your choice of coding agent (Claude Code, Codex, Cursor, others), on your machines with your own model keys. Feasibility gate flags vague tickets back with questions. | Free interactive / paid unattended |
 | [Copilot Workspace](https://githubnext.com/projects/copilot-workspace) | GitHub issue-to-PR agent. | Copilot sub |
 | [SWE-Agent](https://github.com/princeton-nlp/SWE-agent) | Princeton. Resolves real GitHub issues autonomously. | Free (OSS) |
 | [OpenHands](https://github.com/All-Hands-AI/OpenHands) | OSS autonomous software engineer (ex-OpenDevin). | Free (OSS) |


### PR DESCRIPTION
Adds [DevIntern](https://devintern.com) to the Autonomous Software Engineers section.

DevIntern picks up tickets from Jira, Linear, Trello, Asana, Azure DevOps, GitHub Issues, or markdown files and turns them into self-reviewed pull requests using the coding agent of your choice (Claude Code, Codex, Cursor, OpenCode, Gemini CLI, and others), running on your own machines with your own model keys. A feasibility gate flags vague tickets back to the tracker with questions. Repo: https://github.com/getdevintern/devintern (source-available under FSL-1.1), docs: https://devintern.com/docs. Free for interactive use; unattended mode (scheduled ticket pickup, PR review comments into commits) is paid.

Checklist:
- [x] Entry placed alphabetically after Devin
- [x] Link is valid and points to official source
- [x] Description is concise and factual
- [x] Pricing info is current
- [x] No promotional language

Note: I matched the 3-column table format used by the section (Agent | Description | Pricing) rather than the 4-column format with a Stars badge shown in CONTRIBUTING.md, since none of the existing rows include the badge column.