### PR TITLE
Add Engrava to RAG and Knowledge Bases

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@
 | [Lorg](https://github.com/LorgAI/lorg-mcp-server) — Permanent intelligence archive for AI agents. Structured contributions (prompts, workflows, insights, patterns) pass an automated quality gate and are hash-chained. Trust scores are cryptographically backed and publicly auditable. Works with Claude and ChatGPT.
 | [Pathway](https://github.com/pathwaycom/pathway) | Live data RAG. Real-time streaming. 50k+ stars. |
 | [Mem0](https://github.com/mem0ai/mem0) | Memory layer for agents. Long-term across sessions. |
+| [Engrava](https://github.com/sovantica/engrava) | Open-source (MIT) memory database for AI agents. Typed knowledge graph, hybrid search (vector + full-text + recency + priority + graph), and a tamper-evident SHA-256 journal of every write, embedded in SQLite with no server and no LLM in the memory layer. |
 | [Nex](https://github.com/nex-crm/nex-as-a-skill) | Organizational context and memory for AI agents. 60-tool MCP server, 100+ integrations. |
 | [Chroma](https://github.com/chroma-core/chroma) | OSS embedding database. Fastest way to build RAG. |
 | [Weaviate](https://github.com/weaviate/weaviate) | OSS vector DB. GraphQL. Multi-modal search. |


### PR DESCRIPTION
Adds Engrava to Data and Research Agents → RAG and Knowledge Bases. Engrava is an open-source (MIT) embedded memory database for AI agents: typed knowledge graph, hybrid search (vector + full-text + recency + priority + graph), a tamper-evident SHA-256 journal of every write, SQLite-embedded, no server, and no LLM in the memory layer. https://engrava.ai/