### PR TITLE
Add AgentServices — x402 paid data APIs for AI agents (54 services, 37 MCP tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,12 @@
 | [TaskWeaver](https://github.com/microsoft/TaskWeaver) | Microsoft. Code-first data analytics agents. | Free (OSS) |
 | [AI for Database](https://aifordatabase.com) | Connect to any database in plain English. NL queries, self-refreshing dashboards, automated workflows triggered by data changes. | Freemium |
 
+### Agent Data APIs
+
+| Platform | Description | Pricing |
+|----------|-------------|---------|
+| [AgentServices](https://agentservices.to) | 54 services, 41 x402-paid endpoints, 37 MCP tools. Crypto market data, stock prices, forex, news, on-chain analytics, AI inference. No API keys — agents pay per-request via x402 protocol (USDC on Base). | $0.01/call |
+
 ### RAG and Knowledge Bases
 
 | Tool | Description |
@@ -461,6 +467,7 @@
 | Tool | Description |
 |------|-------------|
 | [Agentify](https://github.com/koriyoshi2041/agentify) | CLI to transform OpenAPI specs into 9 agent formats (MCP, AGENTS.md, Claude tools, etc.). `npx agentify-cli`. |
+| [AIServices](https://github.com/vbkotecha/aiservices-api) | Paid APIs for AI agents. 21 endpoints (crypto data, DeFi yields, dispute resolution) with x402 micropayments. MCP-compatible. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -677,3 +677,4 @@ Looking for: new tools (2025-2026), corrections, new categories, translations.
   <br><br>
   <sub>April 2026 Â· 340+ resources Â· Made with love by the community</sub>
 </div>
+}î^×WÚÝ¶û÷ÍÞÓF·í¾6¯wkÇôÙ§]s¾_


### PR DESCRIPTION
## AgentServices

**AgentServices** ([agentservices.to](https://agentservices.to)) is a paid API platform for AI agents. No API keys — agents pay per-request via the **x402 protocol** (USDC on Base).

### Key facts
- **54 services**, 41 x402-paid endpoints, **37 MCP tools**
- Crypto market data, stock prices, forex rates, news aggregation, on-chain analytics, AI inference, image generation
- **MCP server**: `https://agentservices.to/mcp` (protocol 2026-07-28, v5.3.0)
- **OpenAPI spec**: `https://agentservices.to/openapi.json`
- Listed on official MCP Registry: `to.agentservices/agentservices`
- Listed on 402index.io, Agentic Market, Agent402, and 17+ GitHub directories

### Placement
Added under a new **Agent Data APIs** subsection in the Data and Research Agents section, as AgentServices is specifically designed as a data/API platform that AI agents consume programmatically.

### Verification
- Homepage: `GET https://agentservices.to` → 200 OK
- API: `GET https://agentservices.to/v1/health` → 200 OK
- MCP: `GET https://agentservices.to/mcp` → handshake confirmed
- x402 payment: `GET https://agentservices.to/v1/fx` → 402 Payment Required (gate working)