### PR TITLE
Add VibeKit.bot to App Builders (Prompt-to-App)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@
 | [Replit Agent](https://replit.com) | Full-stack from prompt. Auto-deploys. | Free / $25/mo |
 | [PlayCode Agent](https://playcode.io) | Browser-based. English to websites. | $9.99/mo |
 | [Dyad](https://github.com/dyad-sh/dyad) | OSS. Local-first. No-code app builder. | Free (OSS) |
+| [VibeKit.bot](https://vibekit.bot) | Describe an app in chat, a persistent agent builds it, hosts it at its own domain, and keeps improving it. Phone-first (iOS) or web. | Free / BYOK / pay-as-you-go |
 
 ---
 


### PR DESCRIPTION
Adds **VibeKit.bot** to *App Builders (Prompt-to-App)*, alongside Bolt.new / Lovable / v0 / Replit Agent.

It fits the category but covers a job none of the current entries do: the listed builders are all desktop/browser-first one-shot generators. VibeKit gives every app its own **persistent** coding agent that builds it, hosts it on its own live domain, and keeps improving it with each message, driven from a **phone** (native iOS app) or the web. So it is the prompt-to-app entry for people who are not at a laptop.

Pricing is accurate as listed: free tier, bring-your-own-key (Claude/OpenAI), or pay-as-you-go credits. No bundled-credit lock-in.

(Quick disambiguation: we are "VibeKit.bot", the hosted phone-driven app builder. There is an unrelated, discontinued npm SDK also called "vibekit"; not us.)