### PR TITLE
Add Failproof AI to observability tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@
 
 | Tool | Description |
 |------|-------------|
+| [Failproof AI](https://github.com/FailproofAI/failproofai) | Open-source runtime reliability platform for AI agents. Runtime guardrails, workflow replay, policy enforcement, tracing, and production debugging. |
 | [Langfuse](https://github.com/langfuse/langfuse) | OSS LLM observability. Traces, evals, prompts. |
 | [LangSmith](https://smith.langchain.com) | LangChain platform. Tracing, testing, evaluation. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback for AI agent config changes. Monitors health endpoint, reverts config + restarts service on failures. Zero deps. |


### PR DESCRIPTION
## Summary

Add **Failproof AI** to the **Observability and Evaluation** section.

## About Failproof AI

**What:** Open-source runtime reliability platform for AI agents.

**Features:**
- Runtime guardrails
- Workflow replay
- Policy enforcement
- Runtime tracing
- Production debugging

**Works with:**
- Claude Code
- OpenAI Codex
- Cursor
- GitHub Copilot CLI
- OpenClaw
- Hermes
- Devin
- Goose

**Repo:**
https://github.com/FailproofAI/failproofai