### PR TITLE
Add Zooid to Self-Hosted Agents and UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@
 | [KinBot](https://github.com/MarlBurroW/kinbot) | Self-hosted AI agent platform. Persistent memory (hybrid search + LLM re-ranking), 23+ providers (including Ollama), plugin store, mini-apps SDK, cron scheduling, 6 messaging channels. SQLite, runs on a Pi. |
 | [Anything LLM](https://github.com/Mintplex-Labs/anything-llm) | All-in-one AI app. RAG, agents. Desktop + Docker. |
 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | Data interaction with local LLM. 100% private. |
+| [Zooid](https://github.com/zooid-ai/zooid) | Self-hostable team-chat surface (Slack alternative on Matrix) where you run and supervise AI agents as first-class teammates. Any ACP agent (Claude Code, Codex, opencode, goose) runs sandboxed with approval cards, tool calls, and live plans. MIT. |
 
 ---
 


### PR DESCRIPTION
Adds **Zooid** to the **Self-Hosted Agents and UIs** section.

Zooid is not an AI agent itself — it is the **surface / orchestrator you run agents in**: an open-source, self-hostable **Slack alternative built on Matrix** where any ACP agent (Claude Code, Codex, opencode, goose) runs as a supervised, first-class teammate (approval cards, tool calls, live plans, sandboxed). It sits naturally alongside Open WebUI and LibreChat in this section.

- Repo: https://github.com/zooid-ai/zooid · Site: https://zooid.dev · License: MIT

I am the maker — happy to adjust the wording, placement, or ordering to fit your conventions.
