### PR TITLE
Add Agent-First CLI Specs to Protocols and Standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@
 | [Tool Use (Anthropic)](https://docs.anthropic.com/en/docs/build-with-claude/tool-use) | Claude native tool-use. Structured JSON. |
 | [OpenAPI](https://github.com/OAI/OpenAPI-Specification) | Industry-standard API spec. Foundation for agent tools. |
 | [HCS (Hashgraph Consensus Service)](https://hol.org) | Hedera open standards for agent identity (HCS-14 UAIDs), trustless P2P communication (HCS-10), and cross-protocol bridging. 187K+ verified agents. |
+| [Agent-First CLI Specs](https://cli-specs.intrane.fr) | Four open MIT specs for agent-driven CLIs: output contract (stdout=data, stderr=context, semantic exit codes, typed errors, help-json), guide command (embedded mental model), feedback command (dual-write relay), self-update (content-hash, atomic swap). 5 reference implementations. |
 
 ### Protocol Tooling
 


### PR DESCRIPTION
## What

Added [Agent-First CLI Specs](https://cli-specs.intrane.fr) to the **Protocols and Standards** section.

## Why

Four open MIT-licensed specs that make any CLI agent-first — each independently adoptable in ~30 minutes:

1. **cli-output-spec** — stdout=data, stderr=context, semantic exit codes (0/80-89/90-99/100-109/110-119), typed errors, `help-json`
2. **cli-guide-spec** — `guide` command that bakes the full operator mental model into the binary
3. **cli-feedback-spec** — `feedback` command that dual-writes to the app's endpoint + a central relay (idempotent, never-fail)
4. **cli-update-spec** — `update` command with content-hash versioning, verify-then-swap, passive stderr nudge

5 reference implementations across Go and machin (MFL): grepapi, mago, automaintainer, remotecmd, chatsnip — all 4/4 conforming.

This fits the Protocols and Standards section alongside MCP, A2A, and GNAP — it's a convention/standard that agent-driven tools can adopt, not a framework or app.

- Landing: https://cli-specs.intrane.fr
- Blog: https://blog.intrane.fr/agent-first-cli-specs
- Spec repos: [cli-output-spec](https://github.com/javimosch/cli-output-spec), [cli-guide-spec](https://github.com/javimosch/cli-guide-spec), [cli-feedback-spec](https://github.com/javimosch/cli-feedback-spec), [cli-update-spec](https://github.com/javimosch/cli-update-spec)