### PR TITLE
Add Orkas to Multi-Agent Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@
 | [Meta AI](https://meta.ai) | Llama-powered. WhatsApp/Messenger. Manus acquisition. | Free |
 | [TeamHero](https://github.com/sagiyaacoby/TeamHero) | Open-source multi-agent orchestration with web dashboard, task lifecycle, knowledge base, and autopilot mode. Built on Claude Code. Runs locally. | Free (OSS) |
 | [Microsoft Copilot](https://copilot.microsoft.com) | Office 365 integration. Enterprise. | Free / $30/user |
+| [Orkas](https://github.com/Orkas-AI/Orkas) | Local-first multi-agent desktop application where a Commander coordinates specialist agents across research, coding, data analysis, documents, and media. | Free (OSS, MIT) |
 | [Coze](https://coze.com) | ByteDance agent builder. Visual workflow. Plugin marketplace. | Free / Paid |
 | [Cursor AI Automated Team](https://github.com/joinwell52-AI/joinwell52) | 4-role AI team (PM+DEV+OPS+QA) in Cursor IDE. File-based task routing, auto patrol bot. 87 person-days in 17 days. | Free / OSS |
 


### PR DESCRIPTION
## Summary

Adds Orkas to the Multi-Agent Platforms section.

Orkas is an MIT-licensed, local-first desktop application where a Commander coordinates specialist agents in parallel or sequentially. It supports bring-your-own model keys and local model endpoints.

## Verification

- Public and actively maintained
- MIT licensed
- English and Chinese documentation available
- No existing Orkas entry found
- Repository: https://github.com/Orkas-AI/Orkas

## Account migration

This replaces #449, which was closed only to move the source fork from Orkas-AI to BlueSkyID666. The proposed content is unchanged.
