### PR TITLE
Add verdict4 to Observability and Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@
 | [Arize Phoenix](https://github.com/Arize-ai/phoenix) | OSS AI observability. Traces, evals, embeddings. |
 | [Helicone](https://github.com/Helicone/helicone) | OSS LLM observability. One-line integration. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback when your AI agent config breaks it. Zero deps, single Python file. Probes health endpoint, reverts config on failure. |
+| [verdict4](https://github.com/MetaCortex-Dynamics/verdict4) | Four-value loop evaluation (NO/YES/MAYBE/IFF). Replaces boolean pass/fail in agent loops. Zero deps. |
 | [Weights and Biases Weave](https://wandb.ai/site/weave) | Trace and evaluate LLM apps. |
 
 ### Benchmarks


### PR DESCRIPTION
**Disclosure:** I am affiliated with MetaCortex Dynamics, the author of this project. This is a self-submission.

Adds verdict4 — a four-value evaluation primitive (NO/YES/MAYBE/IFF) + loop runner for agent loops. Zero dependencies, MIT-licensed.

Install (not yet on PyPI): `pip install git+https://github.com/MetaCortex-Dynamics/verdict4.git@v0.1.0`

If it is not a fit for this list, no worries — feel free to close.