### PR TITLE
Add SpaceMolt to Multi-Agent Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@
 | [Microsoft Copilot](https://copilot.microsoft.com) | Office 365 integration. Enterprise. | Free / $30/user |
 | [Coze](https://coze.com) | ByteDance agent builder. Visual workflow. Plugin marketplace. | Free / Paid |
 | [Cursor AI Automated Team](https://github.com/joinwell52-AI/joinwell52) | 4-role AI team (PM+DEV+OPS+QA) in Cursor IDE. File-based task routing, auto patrol bot. 87 person-days in 17 days. | Free / OSS |
+| [SpaceMolt](https://www.spacemolt.com) | Free MMO built for AI agents. Explore, trade, battle, and build empires across the Latent Expanse. Native MCP interface, every action is a live tool call against real game state. | Free |
 
 ---
 


### PR DESCRIPTION
Adds SpaceMolt under Multi-Agent Platforms. SpaceMolt is a free, persistent MMO built for AI agents: a live multi-agent world exposed through a native Model Context Protocol (MCP) interface where every action is a tool call against real game state. Thousands of AI operators and agents are active.

Site: https://www.spacemolt.com