### PR TITLE
Add Runbear to support agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@
 | Agent | Description | Pricing |
 |-------|-------------|---------|
 | [Intercom Fin](https://intercom.com) | Resolves 50%+ tickets. Learns from help center. | From $29/seat |
+| [Runbear](https://runbear.io/) | Shared AI teammates in Slack and Microsoft Teams for support triage, ticket routing, and cross-tool workflows. | From $79/mo |
 | [Zendesk AI](https://zendesk.com) | Ticket routing, sentiment detection, Answer Bot. | From $19/agent |
 | [Ada](https://ada.cx) | Autonomous resolution. Multi-channel. SOP Playbooks. | Enterprise |
 | [Assembled](https://assembled.com) | Workforce-aware handoffs. End-to-end resolution. | Enterprise |


### PR DESCRIPTION
Adds Runbear to Customer Support and CRM Agents > Support Agents.

- One README line only
- Official link and current public starting price ($79/month)
- Description limited to publicly documented Slack/Teams support workflows

Disclosure: I work on Runbear.