### PR TITLE
Add Hellomatik to Support Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@
 | [Assembled](https://assembled.com) | Workforce-aware handoffs. End-to-end resolution. | Enterprise |
 | [Freshdesk Freddy AI](https://freshworks.com) | Auto-triage, smart routing, predictive analytics. | From $15/agent |
 | [Dixa (Mim)](https://dixa.com) | Conversational CRM. AI routing and prioritization. | Enterprise |
+| [Hellomatik](https://hellomatik.com) | Turns company knowledge into agents that answer, sell and book across WhatsApp, email and web. | Paid |
 
 ### AI-Powered CRMs
 


### PR DESCRIPTION
Adds **Hellomatik** to the **Support Agents** table.

Hellomatik turns a company's own knowledge into AI agents that answer, sell and book across WhatsApp, email and web (integrations: Shopify, Stripe, Sage). It's a natural peer to Intercom Fin / Ada / Zendesk AI already in the table — matched the `| Agent | Description | Pricing |` format. Thanks for the list!