### PR TITLE
Add lucinate to Terminal and CLI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 | [Cline](https://github.com/cline/cline) | VS Code extension. Full terminal and browser access for Claude/GPT. | Free + API |
 | [RooCode](https://github.com/RooVetGit/Roo-Code) | Cline fork. Structured modes. Reduced hallucinations. | Free + API |
 | [Kilo Code](https://kilocode.ai) | Structured modes. Tighter context. | Free + API |
+| [lucinate](https://github.com/lucinate-ai/lucinate) | Multi-backend terminal AI chat client for OpenClaw, Hermes, Ollama, and OpenAI-compatible APIs. Features routines, multi-agent switching, tool call cards, and local agent skills. | Free + API |
 | [OpenCode](https://github.com/opencode-ai/opencode) | BYOK terminal agent for Cursor refugees. | Free + API |
 | [Caliber](https://github.com/caliber-ai-org/ai-setup) | CLI that fingerprints projects and generates/syncs AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md). Scores quality. | Free + API |
 


### PR DESCRIPTION
### Add [lucinate](https://github.com/lucinate-ai/lucinate)

A multi-backend terminal AI chat client for OpenClaw, Hermes, Ollama, and OpenAI-compatible APIs — with routines, multi-agent switching, tool call cards, and local agent skills, all in the TUI.

**Why it fits:** lucinate is a terminal-native AI agent chat client, fitting naturally in the "Terminal and CLI Agents" section alongside other tools that bring AI to the command line.

**Alphabetical order:** Inserted between "Kilo Code" and "OpenCode".

- Apache 2.0 licensed, actively maintained
- Cross-platform (Linux, macOS, Windows)