### PR TITLE
Add whatbroke to Tracing and Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@
 | [Helicone](https://github.com/Helicone/helicone) | OSS LLM observability. One-line integration. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback when your AI agent config breaks it. Zero deps, single Python file. Probes health endpoint, reverts config on failure. |
 | [Weights and Biases Weave](https://wandb.ai/site/weave) | Trace and evaluate LLM apps. |
+| [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) | CLI that diffs two agent runs. Tool calls, args, cost, latency, outcome flips, flake detection. |
 
 ### Benchmarks
 


### PR DESCRIPTION
Adds whatbroke under Observability and Evaluation. It's a CLI I built that diffs two agent runs so you can see what changed after a prompt or model swap: tool calls, order, args, cost, latency, and outcome flips, with flake detection across repeats. Open source (MIT), TypeScript, on npm as whatbroke-cli, free to use. Link checked, no duplicate on the list, description kept factual.