### PR TITLE
Add KittyClaw to Self-Hosted Agents and UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@
 | [LibreChat](https://github.com/danny-avila/LibreChat) | Self-hosted multi-model chat. All major providers. |
 | [LobeChat](https://github.com/lobehub/lobe-chat) | OSS ChatGPT/Gemini UI. Plugin system. Multi-modal. |
 | [KinBot](https://github.com/MarlBurroW/kinbot) | Self-hosted AI agent platform. Persistent memory (hybrid search + LLM re-ranking), 23+ providers (including Ollama), plugin store, mini-apps SDK, cron scheduling, 6 messaging channels. SQLite, runs on a Pi. |
+| [KittyClaw](https://github.com/Ekioo/KittyClaw) | Self-hosted kanban that dispatches Claude Code agents on tickets. Per-agent roles (SKILL.md), persistent memory, declarative automations, per-ticket cost tracking. .NET/Blazor, SQLite, MIT. Optional Ollama. |
 | [Anything LLM](https://github.com/Mintplex-Labs/anything-llm) | All-in-one AI app. RAG, agents. Desktop + Docker. |
 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | Data interaction with local LLM. 100% private. |
 


### PR DESCRIPTION
Adds [KittyClaw](https://github.com/Ekioo/KittyClaw) to the Self-Hosted Agents and UIs table.

KittyClaw is a self-hosted kanban board that orchestrates Claude Code agents against project tickets. Each agent has a specialist role (SKILL.md), persistent memory across runs, and a declarative automation engine fires agents on board events. Per-ticket token cost tracking, scheduled tickets, optional local models via Ollama. .NET 10 / Blazor Server, SQLite, MIT.

Disclosure: I'm the author. Happy to adjust wording or placement.