### PR TITLE
Add Workforce Wave to Voice Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@
 | [Synthesia](https://synthesia.io) | AI video avatars. 120+ languages. Enterprise. | From $22/mo |
 | [Deepgram](https://deepgram.com) | STT and TTS APIs. Sub-300ms latency. | Usage-based |
 | [AssemblyAI](https://assemblyai.com) | STT with diarization, sentiment, summarization. | Usage-based |
+| [Workforce Wave](https://www.workforcewave.com) | AI voice receptionist for service businesses. Answers calls, books appointments, captures leads 24/7. | Usage-based |
 
 ### Open-Source Voice
 


### PR DESCRIPTION
Adds Workforce Wave (https://www.workforcewave.com), an AI voice receptionist platform for service businesses, to the Voice Agents > Platforms and APIs table. Follows the existing table format, alphabetical-order guidance not strictly applicable since the section isn't alpha-sorted currently; entry appended after AssemblyAI. No promotional language, factual description only.