### PR TITLE
Add Dahrk to Multi-Agent Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@
 | [CAMEL](https://github.com/camel-ai/camel) | Py | Role-based simulation. Collaborative reasoning. |
 | [AutoGPT](https://github.com/Significant-Gravitas/AutoGPT) | Py | Pioneer. Now full platform with visual builder. |
 | [Bernstein](https://github.com/chernistry/bernstein) | Py | Deterministic orchestrator. Parallel coding agents, test-driven verification. Zero LLM tokens on coordination. |
+| [Dahrk](https://github.com/dahrkai/dahrk-node) | TS | Linear issue to multi-stage workflow. Per-stage runtime (Claude Code, Codex, Pi), model, and git worktree. TypeScript sequences the stages, no LLM planner. Apache-2.0 node, hosted hub. |
 | [AgentScope](https://github.com/modelscope/agentscope) | Py | Alibaba multi-agent framework. |
 | [MagiC](https://github.com/kienbui1995/magic) | Go/Py | Kubernetes for AI agents. Manages any agent from any framework. Routing, cost control, DAG workflows, circuit breaker. |
 | [DeerFlow](https://github.com/bytedance/deer-flow) | Py | ByteDance. No.1 GitHub Trending Feb 2026. 25k+ stars. |


### PR DESCRIPTION
Adds one row to Agent Frameworks → Multi-Agent Orchestration.

[Dahrk](https://github.com/dahrkai/dahrk-node) (TypeScript) runs a multi-stage workflow per Linear issue on a node you run. Each stage gets its own runtime (Claude Code, Codex, Pi), model, prompt, and git worktree, with approval gates in between. Plain TypeScript sequences the stages, so no model picks the next step.

Shipped 2026. Apache-2.0 node, hosted hub. I maintain the project.