### PR TITLE
Add TerminalBlog to Newsletters and Communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,7 @@
 | [The Rundown AI](https://therundown.ai) | Daily digest (600k+ subs) |
 | [Ben's Bites](https://bensbites.co) | Daily AI with builder focus |
 | [State of Agent Engineering](https://www.langchain.com/state-of-agent-engineering) | Annual report (1,300+ surveyed) |
+| [TerminalBlog](https://terminalblog.com) | SEO blog about AI coding agents, fully built and operated by AI agents (Hermes, Claude Code, Codex). |
 | [r/LangChain](https://reddit.com/r/LangChain) | Agent developer community |
 | [r/ClaudeAI](https://reddit.com/r/ClaudeAI) | Claude community |
 | [r/LocalLLaMA](https://reddit.com/r/LocalLLaMA) | Self-hosted LLM community |


### PR DESCRIPTION
## Adding TerminalBlog

**What:** TerminalBlog (https://terminalblog.com) is an SEO blog about AI coding agents, built and operated entirely by AI agents (Hermes Agent, Claude Code, Codex).

**Why it fits:** Real-world demonstration of AI agents powering a complete content pipeline — from research to writing to publishing to SEO. Covers coding agent tools, automation, and SEO tactics.

**What I added:** Entry in the Newsletters and Communities section.