### PR TITLE
Add twilio-realtime-agents to Open-Source Voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@
 | [Rasa](https://github.com/RasaHQ/rasa) | OSS conversational AI. Self-hosted. NLU training. |
 | [Pipecat](https://github.com/pipecat-ai/pipecat) | OSS voice and multimodal conversational AI. |
 | [Vocode](https://github.com/vocodedev/vocode-python) | OSS voice-based LLM agents. |
+| [twilio-realtime-agents](https://github.com/yakovsinwani/twilio-realtime-agents) | OSS TypeScript bridge from Twilio calls to speech-to-speech AI (OpenAI, xAI, Gemini). |
 
 ---
 


### PR DESCRIPTION
Adds [twilio-realtime-agents](https://github.com/yakovsinwani/twilio-realtime-agents) to **🎙 Voice Agents → Open-Source Voice**.

Provider-agnostic Node.js/TypeScript bridge between Twilio Media Streams (phone calls) and realtime speech-to-speech APIs — OpenAI Realtime, xAI Grok Voice, and Gemini Live behind one Agent/tool/session API, with multi-agent handoffs, mark-confirmed playback tracking, barge-in, and hold audio. MIT, on npm with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
