### PR TITLE
Add NativePort to developer infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@
 | [Skyvern](https://github.com/Skyvern-AI/skyvern) | Vision-driven. GPT-4V navigation without coded selectors. |
 | [Agent S2 (Simular)](https://github.com/simular-ai/Agent-S) | OSS GUI automation framework. |
 | [MultiOn](https://multion.ai) | Reliable web automation API. CAPTCHA handling. |
+| [NativePort](https://nativeport.ai/) | Web-access API gateway for AI agents across search, scraping, browser automation, voice, and model inference providers. |
 | [Browserbase](https://browserbase.com) | Cloud browser infra for agents. Headless at scale. |
 | [Airtop](https://airtop.ai) | Enterprise browser automation. AI integration. |
 | [Amazon Nova Act](https://aws.amazon.com/ai/nova/) | AWS browser automation. Enterprise reliability. |


### PR DESCRIPTION
## Fit

[NativePort](https://nativeport.ai/) is a web-access API gateway that AI agents call to reach search, scraping, browser automation, voice, and model inference providers through one interface. That places it with the tooling in **Browser and Desktop Agents > Developer Infrastructure** — infrastructure developers build agents on, rather than a consumer-facing agent product. It is publicly available and actively maintained.

## Change

One added line — a single table row in `README.md`, inserted after MultiOn:

```markdown
| [NativePort](https://nativeport.ai/) | Web-access API gateway for AI agents across search, scraping, browser automation, voice, and model inference providers. |
```

The entry follows the section's current two-column Tool/Description format.

## Validation

- Diff is exactly 1 file changed, 1 insertion, 0 deletions; no other entries reordered or reformatted.
- `git diff --check` clean; row has the same two-column shape as the rest of the table.
- `https://nativeport.ai/` returns HTTP 200.
- No existing NativePort entry in the README, and no duplicate open or closed PR.
- Branch is based on the current `main`; commit is signed off.
- Description is factual and free of promotional language.

Affiliation: I am submitting this on behalf of NativePort.
