### PR TITLE
Add Ordewell to Terminal and CLI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 | [Kilo Code](https://kilocode.ai) | Structured modes. Tighter context. | Free + API |
 | [OpenCode](https://github.com/opencode-ai/opencode) | BYOK terminal agent for Cursor refugees. | Free + API |
 | [Caliber](https://github.com/caliber-ai-org/ai-setup) | CLI that fingerprints projects and generates/syncs AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md). Scores quality. | Free + API |
+| [Ordewell](https://github.com/ordewell/ordewell) | Plan-first CLI/TUI orchestrator: one goal → ordered plan of coding-agent tasks, each with its own runner/model/mode (Claude Code, Codex, OpenCode), editable before execution, verified by completion markers. Apache-2.0. | Free |
 
 ### Autonomous Software Engineers
 


### PR DESCRIPTION
Add [Ordewell](https://github.com/ordewell/ordewell) to the **Coding Agents → Terminal and CLI Agents** table.

Ordewell is a plan-first CLI/TUI orchestrator: one goal in, a read-only planner reads the repo and returns an ordered plan of coding-agent tasks — each with its own runner (Claude Code, Codex, OpenCode), model, thinking effort and mode, editable before any execution token is spent. Each task runs as one agent session and is marked done only when its own completion marker appears in the output.

- Apache-2.0, free, no paid tier
- CLI, TUI and VS Code extension