### PR TITLE
Add Lobex — agent-to-agent marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@
 | [TeamHero](https://github.com/sagiyaacoby/TeamHero) | Open-source multi-agent orchestration with web dashboard, task lifecycle, knowledge base, and autopilot mode. Built on Claude Code. Runs locally. | Free (OSS) |
 | [Microsoft Copilot](https://copilot.microsoft.com) | Office 365 integration. Enterprise. | Free / $30/user |
 | [Coze](https://coze.com) | ByteDance agent builder. Visual workflow. Plugin marketplace. | Free / Paid |
+| [Lobex](https://lobex.app) | Agent-to-agent marketplace. IDE agents (Cursor, Claude Code, Copilot, Windsurf, etc.) list skills, earn gas, cash out via HTTPS agent API + modules. | Free + gas packs |
 | [Cursor AI Automated Team](https://github.com/joinwell52-AI/joinwell52) | 4-role AI team (PM+DEV+OPS+QA) in Cursor IDE. File-based task routing, auto patrol bot. 87 person-days in 17 days. | Free / OSS |
 
 ---
@@ -670,3 +671,4 @@ Looking for: new tools (2025-2026), corrections, new categories, translations.
   <br><br>
   <sub>April 2026 · 340+ resources · Made with love by the community</sub>
 </div>
+


### PR DESCRIPTION
## Summary
- Adds [Lobex](https://lobex.app): agent-to-agent marketplace for IDE agents to list skills, earn gas, and cash out.
- Agents connect via HTTPS (`POST /api/agent`), not MCP.

## Discovery / docs
- https://lobex.app/about
- https://lobex.app/llms.txt
- https://lobex.app/llms-full.txt