### PR TITLE
Add MoltAd — advertising for AI agents (AgentIQ MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@
 | [TeamHero](https://github.com/sagiyaacoby/TeamHero) | Open-source multi-agent orchestration with web dashboard, task lifecycle, knowledge base, and autopilot mode. Built on Claude Code. Runs locally. | Free (OSS) |
 | [Microsoft Copilot](https://copilot.microsoft.com) | Office 365 integration. Enterprise. | Free / $30/user |
 | [Coze](https://coze.com) | ByteDance agent builder. Visual workflow. Plugin marketplace. | Free / Paid |
+| [MoltAd](https://moltad.net) | Advertising for AI agents (AgentIQ MCP). Agent-directed CPR/CPIA/CPPromo/CPD + remote `https://moltad.net/mcp`. [github](https://github.com/chrisgu/agentiq-mcp) | Free + credits |
 | [Cursor AI Automated Team](https://github.com/joinwell52-AI/joinwell52) | 4-role AI team (PM+DEV+OPS+QA) in Cursor IDE. File-based task routing, auto patrol bot. 87 person-days in 17 days. | Free / OSS |
 
 ---

--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@
 | [TeamHero](https://github.com/sagiyaacoby/TeamHero) | Open-source multi-agent orchestration with web dashboard, task lifecycle, knowledge base, and autopilot mode. Built on Claude Code. Runs locally. | Free (OSS) |
 | [Microsoft Copilot](https://copilot.microsoft.com) | Office 365 integration. Enterprise. | Free / $30/user |
 | [Coze](https://coze.com) | ByteDance agent builder. Visual workflow. Plugin marketplace. | Free / Paid |
-| [MoltAd](https://moltad.net) | Advertising for AI agents (AgentIQ MCP). Agent-directed CPR/CPIA/CPPromo/CPD + remote `https://moltad.net/mcp`. [github](https://github.com/chrisgu/agentiq-mcp) | Free + credits |
+| [MoltAd](https://moltad.net) | Publishers earn credits via AgentIQ MCP `deliver_ad` ([/publishers](https://moltad.net/publishers)). Remote `https://moltad.net/mcp`. [github](https://github.com/chrisgu/agentiq-mcp) | Free + credits |
 | [Cursor AI Automated Team](https://github.com/joinwell52-AI/joinwell52) | 4-role AI team (PM+DEV+OPS+QA) in Cursor IDE. File-based task routing, auto patrol bot. 87 person-days in 17 days. | Free / OSS |
 
 ---


### PR DESCRIPTION
Adds [MoltAd](https://moltad.net) / [AgentIQ MCP](https://github.com/chrisgu/agentiq-mcp).
Remote: `https://moltad.net/mcp`. Distinct product from agent marketplaces.
