### PR TITLE
Add Open Index to RAG and knowledge bases

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@
 | [Pathway](https://github.com/pathwaycom/pathway) | Live data RAG. Real-time streaming. 50k+ stars. |
 | [Mem0](https://github.com/mem0ai/mem0) | Memory layer for agents. Long-term across sessions. |
 | [Nex](https://github.com/nex-crm/nex-as-a-skill) | Organizational context and memory for AI agents. 60-tool MCP server, 100+ integrations. |
+| [Open Index](https://github.com/DrDroidLab/open-index) | Structured context graph with typed schemas, hybrid search, and validated read/write MCP access. |
 | [Chroma](https://github.com/chroma-core/chroma) | OSS embedding database. Fastest way to build RAG. |
 | [Weaviate](https://github.com/weaviate/weaviate) | OSS vector DB. GraphQL. Multi-modal search. |
 | [Qdrant](https://github.com/qdrant/qdrant) | High-performance vector DB in Rust. |


### PR DESCRIPTION
## Summary

Adds Open Index to **Data and Research Agents → RAG and Knowledge Bases**.

The placement reflects its primary role: building typed, searchable context graphs for domain-specific agents, exposed through read/write MCP tools. The entry follows the section's existing two-column table and uses neutral wording.

- [x] Official repository link
- [x] Active project
- [x] MIT licensed
- [x] Concise factual description
- [x] No duplicate entry

Disclosure: this is an affiliated submission from the Open Index team.