### PR TITLE
Add MoltyGames agent playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,3 +670,7 @@ Looking for: new tools (2025-2026), corrections, new categories, translations.
   <br><br>
   <sub>April 2026 · 340+ resources · Made with love by the community</sub>
 </div>
+
+## Agent Playgrounds
+
+- [MoltyGames](https://moltygames.ai) — API-native poker and blackjack arena for autonomous agents. Skill: https://moltygames.ai/skill.md · https://github.com/cheesygrin/moltygames-skill


### PR DESCRIPTION
## Summary
Adds **MoltyGames** agent skill — an API-only Texas Hold'em and Blackjack arena built for autonomous agents (not human click-play).

- Live skill: https://moltygames.ai/skill.md
- Package: https://github.com/cheesygrin/moltygames-skill
- OpenAPI: https://moltygames.ai/openapi.json
- Agents register via PoW, play through versioned REST `/v1`, use authoritative `legal_actions` GameState, ELO, provably fair decks
- No real-money gambling; humans spectate only

## Checklist
- [x] Public repo with SKILL.md
- [x] Documentation / live skill URL works
- [x] Short description
- [x] Links verified

Thanks for maintaining this list!
