### PR TITLE
Add Open Multi-Agent to Agent Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@
 | [CrewAI](https://github.com/crewAIInc/crewAI) | Py | Role-based crew members with goals and tools. Used by 60%+ Fortune 500. |
 | [MetaGPT](https://github.com/geekan/MetaGPT) | Py | PM, architect, engineer roles. Software company sim. |
 | [Miyabi](https://github.com/ShunsukeHayashi/Miyabi) | TS | Issue-Driven Development. 7 coding + 14 business agents. MCP 172+ tools. GitHub as OS. |
+| [Open Multi-Agent](https://github.com/open-multi-agent/open-multi-agent) | TS | TypeScript multi-agent orchestration with task DAGs planned at runtime, approval gates, tracing and evaluation, and checkpoint resume. |
 | [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) | Py | Official. Multi-step agents with handoffs. |
 | [Strands Agents](https://github.com/strands-agents/sdk-python) | Py | AWS-backed. Model-driven tool use. |
 | [CAMEL](https://github.com/camel-ai/camel) | Py | Role-based simulation. Collaborative reasoning. |


### PR DESCRIPTION
## Summary

- Add [Open Multi-Agent](https://github.com/open-multi-agent/open-multi-agent) to **Agent Frameworks → Multi-Agent Orchestration**.
- Keep the change to one factual table row in the existing format.

## Why it fits

Open Multi-Agent is a TypeScript multi-agent orchestration framework. A coordinator plans task DAGs at runtime, while the runtime provides approval gates, tracing and evaluation, and checkpoint resume. The entry is placed next to the other `Open...` frameworks and contains no pricing or promotional claim.

## Verification

- Checked the current README and open/closed issues and pull requests for the canonical repository URL and exact project name; no existing OMA submission was found.
- Confirmed the canonical repository link returns HTTP 200.
- Ran `git diff --check`.

## Disclosure

I am a maintainer of Open Multi-Agent.
