### PR TITLE
Add Data Studio Agent to Data Analysis section

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@
 | [Signals CLI](https://github.com/sortlist/signals-cli) | Intent signal CLI. LinkedIn engagers, keyword posters, job changers, funding events. JSON output for agent pipelines. | Paid |
 | [TaskWeaver](https://github.com/microsoft/TaskWeaver) | Microsoft. Code-first data analytics agents. | Free (OSS) |
 | [AI for Database](https://aifordatabase.com) | Connect to any database in plain English. NL queries, self-refreshing dashboards, automated workflows triggered by data changes. | Freemium |
+| [DocKit](https://www.geekfun.club/products/dockit/) | Open-source NoSQL GUI with built-in Data AI Agent. Write natural language queries for MongoDB, Elasticsearch, DynamoDB, and OpenSearch. Supports 12 AI providers. Privacy-first desktop app built with Tauri. | Free (OSS) |
 
 ### RAG and Knowledge Bases
 

--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@
 | [TaskWeaver](https://github.com/microsoft/TaskWeaver) | Microsoft. Code-first data analytics agents. | Free (OSS) |
 | [AI for Database](https://aifordatabase.com) | Connect to any database in plain English. NL queries, self-refreshing dashboards, automated workflows triggered by data changes. | Freemium |
 | [DocKit](https://www.geekfun.club/products/dockit/) | Open-source NoSQL GUI with built-in Data AI Agent. Write natural language queries for MongoDB, Elasticsearch, DynamoDB, and OpenSearch. Supports 12 AI providers. Privacy-first desktop app built with Tauri. | Free (OSS) |
+| [Data Studio Agent](https://github.com/geek-fun/data-studio-agent) | One MCP server for 70+ SQL and NoSQL databases. Gives AI agents secure database access via dockit/sqlkit bridges. Credentials never leave the apps. Three-tier permission model (Read Only / Data Read-Write / Full Access). 79 tools. Claude Code, Cursor, Codex, OpenCode. | Free (OSS) |
 
 ### RAG and Knowledge Bases
 


### PR DESCRIPTION
## What

Adds [Data Studio Agent](https://github.com/geek-fun/data-studio-agent) to the **Data Analysis** section under **Data and Research Agents**.

## Why

One MCP server that gives AI coding agents (Claude Code, Cursor, Codex, OpenCode) secure access to 70+ SQL and NoSQL databases through dockit and sqlkit desktop apps.

Key features:
- **79 tools** covering PostgreSQL, MySQL, SQL Server, Oracle, SQLite, MongoDB, Elasticsearch, DynamoDB, and more
- **Credentials never leave the apps** — agents only see opaque connection IDs
- **Three-tier permission model** (Read Only / Data Read-Write / Full Access) with per-connection overrides
- **Statement-level SQL classification** — SQL is parsed and classified before execution
- Published to [MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers?search=data-studio) and [npm](https://www.npmjs.com/package/@geek-fun/data-studio-mcp)
- Open source (Apache 2.0)

Related: DocKit is already listed in the same section — Data Studio Agent is its companion MCP server that extends the same database access to any AI coding agent.