### PR TITLE
Add Hexis to RAG and knowledge bases

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@
 | [Mem0](https://github.com/mem0ai/mem0) | Memory layer for agents. Long-term across sessions. |
 | [Nex](https://github.com/nex-crm/nex-as-a-skill) | Organizational context and memory for AI agents. 60-tool MCP server, 100+ integrations. |
 | [Chroma](https://github.com/chroma-core/chroma) | OSS embedding database. Fastest way to build RAG. |
+| [Hexis](https://github.com/Bevel-Software/Hexis) | Git-backed platform for skills, tools, and context for AI agents. |
 | [Weaviate](https://github.com/weaviate/weaviate) | OSS vector DB. GraphQL. Multi-modal search. |
 | [Qdrant](https://github.com/qdrant/qdrant) | High-performance vector DB in Rust. |
 | [Milvus](https://github.com/milvus-io/milvus) | Cloud-native vector DB. Billion-scale. |


### PR DESCRIPTION
## Summary

Adds Hexis under RAG and Knowledge Bases, where the list groups tools that provide reusable knowledge and context to AI agents.

- [x] Official repository link
- [x] Active project
- [x] Apache 2.0 licensed
- [x] Concise factual description
- [x] No duplicate entry
- [x] Link verified