### PR TITLE
Add Mentioned to Sales and Outreach Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@
 | [Instantly](https://instantly.ai) | AI cold email. Unlimited accounts. Smart rotation. | From $30/mo |
 | [Overloop CLI](https://github.com/sortlist/overloop-cli) | AI outbound CLI. Source 450M+ contacts, email + LinkedIn campaigns, conversations. Agent-native JSON output. | $69-99/mo |
 | [Lavender](https://lavender.ai) | AI email coach. Real-time scoring. | Free / $29/mo |
+| [Mentioned](https://mentioned.to) | Done-for-you Reddit growth for SEO and AI search. Finds ranking threads, publishes native posts and comments, tracks share of voice. | From $2,000/mo |
 
 ---
 


### PR DESCRIPTION
Adds one table row for **Mentioned** (https://mentioned.to) to `Sales and Outreach Agents`.

**What it is:** it finds the Reddit threads already ranking on Google for a client's keywords (and where competitors get recommended), writes and publishes native posts and comments there from managed Reddit accounts, and reports share of voice vs competitors.

**Full disclosure, so you can judge this fairly:**
- I work on Mentioned — this is a self-submission, not a neutral third-party addition.
- It is a **paid managed service**, not self-serve software you sign up for and drive yourself. I put the real number in the Pricing column: from $2,000/month. No free tier.
- It is not open source. Founded 2025.
- Every other row in this section is a self-serve tool with a low entry price, so "this isn't the same kind of thing" is a completely fair reason to close.

One row added, nothing else touched. Thanks for maintaining the list.
