### PR TITLE
Add BitFun to Terminal and CLI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@
 | [OpenAI Codex CLI](https://github.com/openai/codex) | OpenAI terminal agent. Agents SDK. Multi-agent. | ChatGPT sub |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | ⭐ **NEW (Apr 2026)** Google's official open-source terminal agent. ReAct loop. MCP support. 1M context. Apache 2.0. | Free w/ Google account |
 | [Aider](https://github.com/paul-gauthier/aider) | OSS pair programmer. Git-aware. Any LLM. | Free + API |
+| [BitFun](https://github.com/GCWing/BitFun) | Open-source Rust desktop and CLI agent for coding and desktop workflows, with model-agnostic providers, remote workspaces, and stateful Mini Apps. | Free (OSS) |
 | [Cline](https://github.com/cline/cline) | VS Code extension. Full terminal and browser access for Claude/GPT. | Free + API |
 | [RooCode](https://github.com/RooVetGit/Roo-Code) | Cline fork. Structured modes. Reduced hallucinations. | Free + API |
 | [Kilo Code](https://kilocode.ai) | Structured modes. Tighter context. | Free + API |


### PR DESCRIPTION
Adds BitFun to the Coding Agents → Terminal and CLI Agents table.

- links the official open-source repository
- uses a concise factual description based on the project README and app manifests
- lists pricing as Free (OSS)
- confirms there was no existing BitFun entry

The project is actively maintained and provides both desktop and CLI interfaces.