### PR TITLE
Add OpenProgram to general-purpose agent frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@
 | [Pydantic AI](https://github.com/pydantic/pydantic-ai) | Py | Type-safe. Clean Pythonic API. Production-ready. |
 | [DSPy](https://github.com/stanfordnlp/dspy) | Py | Stanford. Programming not prompting. Auto-optimizes. |
 | [Mastra](https://github.com/mastra-ai/mastra) | TS | TypeScript-first. Observational Memory. Apache 2.0. |
+| [OpenProgram](https://github.com/Fzkuji/OpenProgram) | Py | Self-programming agent framework with runtime-managed tools, memory, context, and multi-agent execution. |
 | [Anthropic SDK](https://github.com/anthropics/anthropic-sdk-python) | Py/TS | Official Claude SDK. Tool use, computer control, streaming. |
 | [Google ADK](https://github.com/google/adk-python) | Py | ⭐ Google's Agent Development Kit. Native Gemini. Multi-agent orchestration. |
 


### PR DESCRIPTION
Adds OpenProgram to the General Purpose framework table.

OpenProgram is an actively maintained, open-source Python framework for self-programming agents. Its documented runtime manages tools, memory, DAG context, and multi-agent execution.

- Repository: https://github.com/Fzkuji/OpenProgram
- Documentation: https://openprogram.io/docs/
- License: AGPL-3.0

The entry uses the existing table format, links to the canonical repository, and avoids unsupported claims.