### PR TITLE
Add Atomic Agent (Terminal/CLI Agents + Self-Hosted Agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 | [Kilo Code](https://kilocode.ai) | Structured modes. Tighter context. | Free + API |
 | [OpenCode](https://github.com/opencode-ai/opencode) | BYOK terminal agent for Cursor refugees. | Free + API |
 | [Caliber](https://github.com/caliber-ai-org/ai-setup) | CLI that fingerprints projects and generates/syncs AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md). Scores quality. | Free + API |
+| [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) | Local-first CLI and TUI coding agent (React + ink). Runs open-weight models entirely on your machine via a llama.cpp fork. No account or API key. 56 built-in tools, MCP support, five-layer memory. MIT. | Free (OSS) |
 
 ### Autonomous Software Engineers
 
@@ -424,6 +425,7 @@
 | [KinBot](https://github.com/MarlBurroW/kinbot) | Self-hosted AI agent platform. Persistent memory (hybrid search + LLM re-ranking), 23+ providers (including Ollama), plugin store, mini-apps SDK, cron scheduling, 6 messaging channels. SQLite, runs on a Pi. |
 | [Anything LLM](https://github.com/Mintplex-Labs/anything-llm) | All-in-one AI app. RAG, agents. Desktop + Docker. |
 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | Data interaction with local LLM. 100% private. |
+| [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) | Local-first CLI and TUI coding agent. Runs open-weight models entirely on your machine via a llama.cpp fork. No account or API key. 56 built-in tools, MCP support, five-layer memory. macOS, Linux, Windows. MIT. |
 
 ---
 


### PR DESCRIPTION
## Add Atomic Agent

Hi! I'm the CPO of Atomic Agent, and thanks so much for maintaining this list. It is genuinely one of the most comprehensive maps of the agent ecosystem out there, and our team would be thrilled to be part of it.

**Atomic Agent** is a local-first CLI and TUI coding agent. It runs open-weight models entirely on your machine through a llama.cpp fork, so there is no account or API key required to install and run it. The TUI is built on React and ink. It ships with 56 built-in tools (browser, filesystem, git, memory, vision), supports MCP (Model Context Protocol), and has a five-layer local memory system. Cross-platform on macOS, Linux, and Windows.

Install:
```
curl -fsSL https://atomicagent.io/install | sh
```

### Where I added it
Two sections, since it genuinely fits both:

1. **Coding Agents to Terminal and CLI Agents**: it is a terminal / CLI coding agent, alongside Claude Code, Aider, and OpenCode.
2. **Local and Self-Hosted AI to Self-Hosted Agents and UIs**: it runs fully on your own machine with open weights.

I appended each entry to the end of its section, matching how recent entries were added, and matched each section's exact column format (3 columns with pricing for the CLI section, 2 columns for the self-hosted section). Happy to move, trim, or drop either entry if you would prefer only one.

### Links
- Repo: https://github.com/AtomicBot-ai/atomic-agent (MIT, ~2k stars, actively maintained)
- Site: https://atomicagent.io
- Docs: https://atomicagent.io/docs
- X: https://x.com/atomicagent_io
- Discord: https://discord.gg/Us7qXtDGw

### PR checklist
- [x] Entry added in the appropriate section(s)
- [x] Links are valid and point to the official source
- [x] Description is concise and factual
- [x] Pricing info is current (free and open-source, MIT)
- [x] No promotional language

### A note on project age
Atomic Agent is about 4 months old (first released April 2026), so it is newer than some entries here. It is active and maintained (~2k stars, frequent commits) and it is built by the AtomicBot-ai organization, which ships several established projects. Fully understand if you would rather wait, but wanted to put it forward given how well it fits the CLI and self-hosted categories.

Thanks again for the work you put into this list.
