### PR TITLE
Add Lians agent memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@
 | Tool | Description |
 |------|-------------|
 | [RAGFlow](https://github.com/infiniflow/ragflow) | OSS RAG engine with agent capabilities. |
+| [Lians](https://github.com/Lians-ai/Lians) | Local-first agent memory with MCP, SDKs, SQLite, and point-in-time recall. |
 | [Lorg](https://github.com/LorgAI/lorg-mcp-server) — Permanent intelligence archive for AI agents. Structured contributions (prompts, workflows, insights, patterns) pass an automated quality gate and are hash-chained. Trust scores are cryptographically backed and publicly auditable. Works with Claude and ChatGPT.
 | [Pathway](https://github.com/pathwaycom/pathway) | Live data RAG. Real-time streaming. 50k+ stars. |
 | [Mem0](https://github.com/mem0ai/mem0) | Memory layer for agents. Long-term across sessions. |


### PR DESCRIPTION
Adds Lians beside the other agent-memory and context tools with a concise, factual description of its released interfaces and storage model.

- [x] Active 2025-2026 tool with usable open-source code
- [x] Direct official repository link
- [x] Concise factual description
- [x] No duplicate entry or promotional language

Disclosure: I am a Lians maintainer. This contribution was prepared with AI assistance and reviewed before submission.