### PR TITLE
Add DeepSeek Harness Handbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@
 
 ### Courses and Tutorials
 - [DeepLearning.AI Agent Courses](https://www.deeplearning.ai/) - Free courses with LangChain, CrewAI, AutoGen
+- [DeepSeek Harness Handbook](https://sandbaseai.github.io/deepseek-harness-handbook/) - Agent-first, source-backed guide to DeepSeek Harness architecture, quickstarts, safety, and production operations
 - [HuggingFace Agents Course](https://huggingface.co/learn/agents-course) - Open-source agent dev course
 - [LangGraph Academy](https://academy.langchain.com/) - Official LangGraph path
 - [Anthropic Cookbook](https://github.com/anthropics/anthropic-cookbook) - Claude agent recipes


### PR DESCRIPTION
## Summary

Adds the DeepSeek Harness Handbook to **Learning Resources → Courses and Tutorials**.

The handbook is an actively maintained, open-source learning resource for Agent builders. It covers the official DeepSeek Harness runtime from an agent-first perspective, including:

- source-backed runtime and lifecycle architecture;
- bounded Web, headless, and Python SDK quickstarts;
- tool approval, sandbox, MCP, Skills, and subagent boundaries;
- troubleshooting and production-readiness checklists;
- English canonical content plus multilingual navigation.

## Checklist

- [x] Placed in the appropriate existing section
- [x] Link points to the public canonical site
- [x] Description is concise and factual
- [x] Resource is actively maintained and publicly available
- [x] No duplicate entry exists
- [x] `git diff --check` passes