### PR TITLE
Add SandBase managed agent platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,13 +433,14 @@
 |----------|-------------|---------|
 | [ChatGPT](https://chat.openai.com) | GPTs, Deep Research, Canvas, Agent Mode, vision. GPT-5.4 (monthly updates). | Free / $20+/mo |
 | [Claude](https://claude.ai) | Tool use, computer control, MCP, code exec. Chrome, Excel, Cowork. Claude Sonnet 5 / Opus 4.6. | Free / $20+/mo |
+| [Coze](https://coze.com) | ByteDance agent builder. Visual workflow. Plugin marketplace. | Free / Paid |
+| [Cursor AI Automated Team](https://github.com/joinwell52-AI/joinwell52) | 4-role AI team (PM+DEV+OPS+QA) in Cursor IDE. File-based task routing, auto patrol bot. 87 person-days in 17 days. | Free / OSS |
 | [Gemini](https://gemini.google.com) | Deep Think, Gems, multi-modal. Gemini 3.1 Pro. 1M tokens. Google ecosystem. | Free / $19.99+/mo |
 | [Grok](https://x.ai) | Real-time X data. Grok 4.20. Multi-agent Society of Mind. Image gen. | X Premium+ |
 | [Meta AI](https://meta.ai) | Llama-powered. WhatsApp/Messenger. Manus acquisition. | Free |
-| [TeamHero](https://github.com/sagiyaacoby/TeamHero) | Open-source multi-agent orchestration with web dashboard, task lifecycle, knowledge base, and autopilot mode. Built on Claude Code. Runs locally. | Free (OSS) |
 | [Microsoft Copilot](https://copilot.microsoft.com) | Office 365 integration. Enterprise. | Free / $30/user |
-| [Coze](https://coze.com) | ByteDance agent builder. Visual workflow. Plugin marketplace. | Free / Paid |
-| [Cursor AI Automated Team](https://github.com/joinwell52-AI/joinwell52) | 4-role AI team (PM+DEV+OPS+QA) in Cursor IDE. File-based task routing, auto patrol bot. 87 person-days in 17 days. | Free / OSS |
+| [SandBase](https://github.com/sandbaseai/sandbase-docs) | Managed agents combining model instructions and tools, runnable on demand through endpoints, on schedules as deployments, or in persistent sessions. | Usage-based / $1 free credit |
+| [TeamHero](https://github.com/sagiyaacoby/TeamHero) | Open-source multi-agent orchestration with web dashboard, task lifecycle, knowledge base, and autopilot mode. Built on Claude Code. Runs locally. | Free (OSS) |
 
 ---
 


### PR DESCRIPTION
## What changed

Adds SandBase to the **Multi-Agent Platforms** table and places that table in alphabetical order, as required by the contribution guide.

## Why

SandBase provides publicly available managed agents that combine model instructions and tools and can run through on-demand endpoints, scheduled deployments, or persistent sessions.

## Sources

- https://github.com/sandbaseai/sandbase-docs
- https://docs.sandbase.ai/agents/
- https://docs.sandbase.ai/agents/endpoints
- https://docs.sandbase.ai/agents/deployments
- https://docs.sandbase.ai/agents/sessions
- https://docs.sandbase.ai/admin/billing

## Disclosure

I am affiliated with SandBase. The proposed entry is concise and factual and links directly to the public documentation repository.

## Validation

- Confirmed the project was not already listed
- Kept the section alphabetized
- Ran `git diff --check`
