### PR TITLE
Add LWC to RAG and Knowledge Bases

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@
 |------|-------------|
 | [RAGFlow](https://github.com/infiniflow/ragflow) | OSS RAG engine with agent capabilities. |
 | [Lorg](https://github.com/LorgAI/lorg-mcp-server) — Permanent intelligence archive for AI agents. Structured contributions (prompts, workflows, insights, patterns) pass an automated quality gate and are hash-chained. Trust scores are cryptographically backed and publicly auditable. Works with Claude and ChatGPT.
+| [LWC (Local Wiki CLI)](https://github.com/JanYork/llm-wiki-cli) | Local-first, source-grounded project memory for coding agents with bounded read-only MCP retrieval, citations/provenance, atomic changesets, and optional document/code graphs. Free and open source (Apache-2.0). |
 | [Pathway](https://github.com/pathwaycom/pathway) | Live data RAG. Real-time streaming. 50k+ stars. |
 | [Mem0](https://github.com/mem0ai/mem0) | Memory layer for agents. Long-term across sessions. |
 | [Nex](https://github.com/nex-crm/nex-as-a-skill) | Organizational context and memory for AI agents. 60-tool MCP server, 100+ integrations. |


### PR DESCRIPTION
## Summary

Adds LWC (Local Wiki CLI) to **RAG and Knowledge Bases**.

LWC is a 2026, actively maintained, public agent-memory tool. It provides local-first source-grounded project memory, bounded read-only retrieval through MCP, citations/provenance, atomic changesets, and optional document and code knowledge graphs.

- Official source: https://github.com/JanYork/llm-wiki-cli
- Pricing: free and open source
- License: Apache-2.0
- Latest repository update: 2026-08-14

The description is concise and factual, and `git diff --check` passes.