### PR TITLE
Add Sudarshan (Coding Agents → Autonomous Software Engineers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 | [SWE-Agent](https://github.com/princeton-nlp/SWE-agent) | Princeton. Resolves real GitHub issues autonomously. | Free (OSS) |
 | [OpenHands](https://github.com/All-Hands-AI/OpenHands) | OSS autonomous software engineer (ex-OpenDevin). | Free (OSS) |
 | [Grok Build (xAI)](https://x.ai) | 8 parallel agents for code gen. Multi-agent "Society of Mind" architecture. | xAI sub |
+| [Sudarshan](https://github.com/Suraj1235/sudarshan-superharness) | Provider-neutral build harness. Idea/PRD/spec to verification-gated completion. Cost estimates, budget ceilings, kill-and-resume checkpoints. | Free (OSS) |
 
 ### Code Review and Security
 


### PR DESCRIPTION
Adds [Sudarshan](https://github.com/Suraj1235/sudarshan-superharness) to *Coding Agents → Autonomous Software Engineers* using the existing table format.

**PR requirements:**
- Placement: appended to the section table (the existing table is not alphabetically ordered; happy to move the row if you prefer strict alphabetical placement)
- Link is valid and points to the official source (GitHub repo)
- Description is concise and factual: provider-neutral build harness that takes an idea/PRD/spec and drives a model to completion gated on passing verification commands, with explainable cost estimates, budget ceilings, and checkpoints that resume after interruption
- Pricing is current: Free (OSS), MIT license
- Actively maintained: pushed 2026-08-16, CI green on Linux/macOS/Windows