### PR TITLE
Add Aeon (Agent Frameworks -> General Purpose)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@
 | [Mastra](https://github.com/mastra-ai/mastra) | TS | TypeScript-first. Observational Memory. Apache 2.0. |
 | [Anthropic SDK](https://github.com/anthropics/anthropic-sdk-python) | Py/TS | Official Claude SDK. Tool use, computer control, streaming. |
 | [Google ADK](https://github.com/google/adk-python) | Py | ⭐ Google's Agent Development Kit. Native Gemini. Multi-agent orchestration. |
+| [Aeon](https://github.com/aeonfun/aeon) | MD/Shell | Autonomous framework that runs unattended on GitHub Actions. Cron-scheduled Markdown skills, self-healing (a health skill detects failures, a repair skill fixes them by PR), six coding-agent harnesses. MIT. |
 
 ### Multi-Agent Orchestration
 


### PR DESCRIPTION
Adding [Aeon](https://github.com/aeonfun/aeon) under **Agent Frameworks -> General Purpose**.

Aeon is an autonomous agent framework that runs entirely inside GitHub Actions - no server, nothing long-lived. You enable Markdown "skills", schedule them on cron (or trigger on repo events), and each run is a fresh headless coding-agent invocation that commits back to the repo. It self-heals: a health skill detects failing skills and a repair skill fixes them by PR. It also spawns a fleet of isolated clones and dispatches skills to six coding-agent harnesses (Claude Code, Codex, Grok, Pi, Vibe, Kimi) behind one contract.

- Repo: https://github.com/aeonfun/aeon
- License: MIT, ~666 stars, actively maintained (daily commits)
- Fits General Purpose: a broadly applicable autonomous agent framework, distinct from the others here in that its runtime is GitHub Actions rather than a local or hosted process.

Placed in the General Purpose table as a single row; columns match the surrounding entries (Framework | Lang | Description). No promotional language.
