### PR TITLE
Add ClawMetry to Tracing and Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback for AI agent config changes. Monitors health endpoint, reverts config + restarts service on failures. Zero deps. |
 | [Braintrust](https://braintrustdata.com) | Eval-driven development. Experiment tracking. |
 | [Arize Phoenix](https://github.com/Arize-ai/phoenix) | OSS AI observability. Traces, evals, embeddings. |
+| [ClawMetry](https://github.com/vivekchand/clawmetry) | Open-source zero-config observability for AI agent runtimes. Sessions, token costs, live traces, OTLP ingest. pip install clawmetry. |
 | [Helicone](https://github.com/Helicone/helicone) | OSS LLM observability. One-line integration. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback when your AI agent config breaks it. Zero deps, single Python file. Probes health endpoint, reverts config on failure. |
 | [Weights and Biases Weave](https://wandb.ai/site/weave) | Trace and evaluate LLM apps. |

--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback for AI agent config changes. Monitors health endpoint, reverts config + restarts service on failures. Zero deps. |
 | [Braintrust](https://braintrustdata.com) | Eval-driven development. Experiment tracking. |
 | [Arize Phoenix](https://github.com/Arize-ai/phoenix) | OSS AI observability. Traces, evals, embeddings. |
-| [ClawMetry](https://github.com/vivekchand/clawmetry) | Open-source zero-config observability for AI agent runtimes. Sessions, token costs, live traces, OTLP ingest. pip install clawmetry. |
+| [ClawMetry](https://github.com/vivekchand/clawmetry) | Open-source zero-config observability for AI agent runtimes. Sessions, token costs, live traces, OTLP ingest. pip install clawmetry. ([clawmetry.com](https://clawmetry.com)) |
 | [Helicone](https://github.com/Helicone/helicone) | OSS LLM observability. One-line integration. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback when your AI agent config breaks it. Zero deps, single Python file. Probes health endpoint, reverts config on failure. |
 | [Weights and Biases Weave](https://wandb.ai/site/weave) | Trace and evaluate LLM apps. |


### PR DESCRIPTION
Adds [ClawMetry](https://github.com/vivekchand/clawmetry) to the Tracing and Monitoring table.

Open-source (MIT) observability dashboard for AI agent runtimes: session transcripts, token and cost analytics, live traces, and OTLP ingest. Installs with pip install clawmetry, zero config, read-only. Row inserted in alphabetical position.

Website: https://clawmetry.com
