### PR TITLE
Add UIZZE to 3D and Design

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@
 |------|-------------|---------|
 | [Meshy](https://meshy.ai) | Text/image to 3D. Game assets, products. | Free / Paid |
 | [Tripo AI](https://tripo3d.ai) | Fast 3D from text/images. Multi-format export. | Free / Paid |
+| [UIZZE](https://github.com/uizze/uizze) | UI research and anti-UI-slop workflow for coding agents. Free `anti-ui-slop` Skill; full hosted MCP searches 800,000+ real web and iOS screens and adds design contracts, validation, audits, and rendered critique. | Free / Paid |
 | [Vizcom](https://vizcom.ai) | Real-time AI rendering for industrial designers. | From $20/mo |
 
 ---


### PR DESCRIPTION
## Summary

Add UIZZE to the 3D and Design section as a maintained UI research and anti-UI-slop workflow for coding agents.

- Official source: https://github.com/uizze/uizze
- Free `anti-ui-slop` Skill
- Full hosted MCP searches 800,000+ real web and iOS screens and adds design contracts, validation, audits, and rendered critique
- Pricing is stated as Free / Paid, matching the public product split

## Verification

- Entry is alphabetized between Tripo AI and Vizcom.
- `git diff --check` passes.
- Official repository and Skill links return HTTP 200.