### PR TITLE
Add Okto Pulse to no-code agent builders list

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@
 | [Activepieces](https://github.com/activepieces/activepieces) | OSS Zapier alternative with AI. | Free (OSS) |
 | [Temporal](https://github.com/temporalio/temporal) | Durable execution for long-running agent workflows. | Free / Cloud |
 | [Mission Control](https://github.com/MeisnerDan/mission-control) | Cockpit for the agentic era — manage AI agent swarms with autonomous daemon, Field Ops for real-world execution, and approval workflows. | Free (OSS) |
+| [Okto Pulse](https://github.com/OktoLabsAI/okto-pulse) | Local-first SDLC workbench with governed specs, sprints, and tasks — enforced reviewer separation and blocking evidence gates, connected to coding agents via MCP. | Free (OSS) |
 
 ### No-Code Agent Builders
 


### PR DESCRIPTION
Adds Okto Pulse under Task and Workflow Agents > Automation.

Okto Pulse is a local-first SDLC workbench that governs how AI coding agents move work through specs, sprints, and tasks — enforcing reviewer separation (an agent can't validate its own work) and blocking evidence gates before anything reaches "done." Connects to agents over MCP. Listed alongside Temporal and Mission Control as workflow/approval infrastructure for agent-driven work.