### PR TITLE
Add SandBase CLI to protocol tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@
 | Tool | Description |
 |------|-------------|
 | [Agentify](https://github.com/koriyoshi2041/agentify) | CLI to transform OpenAPI specs into 9 agent formats (MCP, AGENTS.md, Claude tools, etc.). `npx agentify-cli`. |
+| [SandBase CLI](https://github.com/sandbaseai/cli) | Apache-2.0 CLI and local MCP bridge that configures 25 AI clients to discover, inspect, and call 2,000+ AI models and APIs through one account. |
 
 ---
 


### PR DESCRIPTION
## Summary

Add SandBase CLI to the Protocol Tooling table. The entry links to the official `sandbaseai` organization repository and uses a concise, factual description.

## Checklist

- [x] Entry is in alphabetical order within its section
- [x] Link is valid and points to the official source
- [x] Description is concise and factual
- [x] Pricing is not part of this section's two-column format
- [x] No promotional language
- [x] Project is active and released in 2026
- [x] No duplicate SandBase entry exists
- [x] `git diff --check` passes

## Why Protocol Tooling

The open-source CLI installs a local MCP bridge across 25 supported AI clients. Its six MCP tools separate endpoint discovery and schema inspection from execution and run retrieval for a catalog of 2,000+ AI models and APIs.