### PR TITLE
Add FutureOS — approval-gated agent across terminal, desktop, mobile & chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@
 | [LobeChat](https://github.com/lobehub/lobe-chat) | OSS ChatGPT/Gemini UI. Plugin system. Multi-modal. |
 | [KinBot](https://github.com/MarlBurroW/kinbot) | Self-hosted AI agent platform. Persistent memory (hybrid search + LLM re-ranking), 23+ providers (including Ollama), plugin store, mini-apps SDK, cron scheduling, 6 messaging channels. SQLite, runs on a Pi. |
 | [Anything LLM](https://github.com/Mintplex-Labs/anything-llm) | All-in-one AI app. RAG, agents. Desktop + Docker. |
+| [FutureOS](https://github.com/futuregene/future-os) | One approval-gated agent across terminal, desktop, mobile, and IM bots. Rust core. 3,800+ models. |
 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | Data interaction with local LLM. 100% private. |
 
 ---


### PR DESCRIPTION
Adding [FutureOS](https://github.com/futuregene/future-os) to the Self-Hosted Agents and UIs table (next to OpenClaw — same category).

FutureOS is an open-source general-purpose agent (MIT + Apache-2.0): a single local Rust gRPC backend drives a terminal UI, desktop app, mobile apps, CLI, and IM bots (Feishu/DingTalk) with shared sessions; every read/write/edit/shell tool call is approval-gated; 3,800+ models across 140+ providers built in, plus any OpenAI-compatible endpoint; local-first data storage.

Entry follows the section's existing table format.