### PR TITLE
Add Coworker to Awesome AI Agents 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 | Agent | Description | Pricing |
 |-------|-------------|---------|
 | [Cursor](https://cursor.com) | VS Code fork. Composer mode for multi-file edits. Claude Sonnet 5, GPT-5, Gemini 3.1. $29.3B valuation. | Free / $20/mo |
+| **[Coworker](https://github.com/leonjackman/coworker)** | Desktop (Electron) | ✅ (MIT) | Free/BYOK | 20+ providers, MCP | Local-first coding agent with memory, HITL, and 11 languages |
 | [GitHub Copilot](https://github.com/features/copilot) | Agent Mode in VS Code. Copilot Workspace issue-to-PR. Multi-model (Claude, GPT-5.4, Gemini 3.1). | $10/mo / $39/mo Pro+ |
 | [Windsurf (Codeium)](https://windsurf.com) | Cascade agentic mode. Project-level memory. 5 parallel agents. | Free / $15/mo |
 | [JetBrains AI](https://www.jetbrains.com/ai/) | Deep integration across all JetBrains IDEs. Context-aware completions. | Included with IDE |


### PR DESCRIPTION

## Add Coworker

**Coworker** is a local-first AI coding assistant desktop app that fits in this list's IDE-Native Agents category.

### Why Coworker
- **Open Source:** MIT licensed, 396+ commits, active development
- **Multi-provider:** 20+ LLM providers including Ollama (local)
- **Full MCP:** 5 transport protocols
- **Desktop app:** Electron-based, 11-language i18n
- **Privacy-first:** All data stays on user's machine

### Links
- GitHub: https://github.com/leonjackman/coworker
- Website: https://coworker.lazzzyboy.com
- Releases: https://github.com/leonjackman/coworker/releases
- License: MIT
