### PR TITLE
Add AmpUp to Sales and Outreach Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@
 
 | Agent | Description | Pricing |
 |-------|-------------|---------|
+| [AmpUp](https://www.ampup.ai) | Agentic sales intelligence and coaching over live CRM and call data. MCP access for pipeline analysis, meeting prep, post-call coaching, roleplay, and CRM updates. | From $37/seat/mo |
 | [Clay](https://clay.com) | AI data enrichment. Personalized outreach at scale. | From $149/mo |
 | [Apollo.io](https://apollo.io) | AI prospecting, sequences, scoring. 275M+ contacts. | Free / $49+/mo |
 | [Instantly](https://instantly.ai) | AI cold email. Unlimited accounts. Smart rotation. | From $30/mo |

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@
 
 | Agent | Description | Pricing |
 |-------|-------------|---------|
-| [AmpUp](https://www.ampup.ai) | Agentic sales intelligence and coaching over live CRM and call data. MCP access for pipeline analysis, meeting prep, post-call coaching, roleplay, and CRM updates. | From $37/seat/mo |
+| [AmpUp](https://www.ampup.ai) | Agentic sales intelligence and coaching over live CRM and call data. MCP access for pipeline analysis, meeting prep, post-call coaching, roleplay, and CRM updates. | From $0.01/API call |
 | [Clay](https://clay.com) | AI data enrichment. Personalized outreach at scale. | From $149/mo |
 | [Apollo.io](https://apollo.io) | AI prospecting, sequences, scoring. 275M+ contacts. | Free / $49+/mo |
 | [Instantly](https://instantly.ai) | AI cold email. Unlimited accounts. Smart rotation. | From $30/mo |


### PR DESCRIPTION
## Summary

- add AmpUp to the Sales and Outreach Agents section
- describe its MCP access to live CRM and call data for pipeline analysis, meeting prep, coaching, roleplay, and CRM updates
- include API-call pricing starting at $0.01 per call

## Sources

- Product: https://www.ampup.ai
- GTM/RevOps workflow: https://www.ampup.ai/blog/claude-code-revenue-ops

## Validation

- git diff --check
- verified the product link returns HTTP 200