### PR TITLE
Add Vetto to AI Safety and Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,7 @@
 | [Rebuff](https://github.com/protectai/rebuff) | Prompt injection detection. |
 | [Lakera Guard](https://lakera.ai) | Real-time protection. Prompt injection, data leakage, toxicity. |
 | [OWASP Top 10 for Agentic Apps](https://owasp.org) | ⭐ **2026 Framework** Goal hijacking, tool misuse, cascading failure mitigations. |
+| [Vetto](https://github.com/shleder/vetto) | Zero-daemon OS security boundary & sandbox for AI coding agents (Landlock/Seatbelt, secret masking, subagent IPC isolation). |
 
 ---
 


### PR DESCRIPTION
### Description

Adds [Vetto](https://github.com/shleder/vetto) to the **AI Safety and Guardrails** section.

**Vetto** is a daemon-less, operator-controlled OS security boundary & sandbox for local AI coding agents (Codex, Claude Code, Cursor, Aider):
- Pre-execution Landlock (Linux ABI 1-4) & Seatbelt (macOS) kernel isolation.
- Automatic secret masking (`~/.ssh`, `~/.aws`, `.env` mapped to `/dev/null`).
- Subagent IPC isolation (masks parent control plane sockets and devtools ports).
- Default-deny network with host-side domain allowlist relay.
- Zero background daemons, zero telemetry.