### PR TITLE
Add Screenpipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@
 | [Milvus](https://github.com/milvus-io/milvus) | Cloud-native vector DB. Billion-scale. |
 | [Pinecone](https://pinecone.io) | Managed vector DB. Serverless. Low-latency. |
 | [iGPT](https://igpt.ai) | Email Intelligence API. Converts email threads into reasoning-ready JSON for agents. |
+| [Screenpipe](https://screenpipe.com) | Local-first computer history that gives AI agents searchable screen and audio context. |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds Screenpipe to RAG and Knowledge Bases as a local-first computer-history context source for AI agents.

## Checklist

- [x] Entry is in an appropriate existing section
- [x] Link points to the official product
- [x] Description is concise and factual
- [x] Product is public and actively maintained
- [x] No promotional language

Disclosure: I maintain Screenpipe. I followed the current two-column format used by this section. Thank you for considering the addition; I am happy to adjust or close it if it is not a fit.
