### PR TITLE
Add SandBase CLI to terminal and CLI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@
 | [Aider](https://github.com/paul-gauthier/aider) | OSS pair programmer. Git-aware. Any LLM. | Free + API |
 | [Cline](https://github.com/cline/cline) | VS Code extension. Full terminal and browser access for Claude/GPT. | Free + API |
 | [RooCode](https://github.com/RooVetGit/Roo-Code) | Cline fork. Structured modes. Reduced hallucinations. | Free + API |
+| [SandBase CLI](https://github.com/sandbaseai/cli) | Local MCP bridge for supported AI clients to discover and run 2,000+ AI models and APIs. | Free CLI + usage-based API |
 | [Kilo Code](https://kilocode.ai) | Structured modes. Tighter context. | Free + API |
 | [OpenCode](https://github.com/opencode-ai/opencode) | BYOK terminal agent for Cursor refugees. | Free + API |
 | [Caliber](https://github.com/caliber-ai-org/ai-setup) | CLI that fingerprints projects and generates/syncs AI agent configs (CLAUDE.md, .cursor/rules/, AGENTS.md). Scores quality. | Free + API |


### PR DESCRIPTION
Adds SandBase CLI to the Terminal and CLI Agents table.

- Official source: https://github.com/sandbaseai/cli
- Description is limited to the documented local MCP bridge and 2,000+ AI model/API access.
- Pricing column reflects a free CLI with usage-based hosted API execution.
- Disclosure: I am affiliated with SandBase and used AI assistance to prepare this factual entry.