### PR TITLE
Add DeepSeek Harness Handbook to learning resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,7 @@
 ## 📚 Learning Resources
 
 ### Courses and Tutorials
+- [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) - Source-backed, Agent-first field guide to the DeepSeek Harness runtime, covering tools, Sessions, plugins, MCP, sandboxing, lifecycle, and troubleshooting. Community-maintained by SandBase.
 - [DeepLearning.AI Agent Courses](https://www.deeplearning.ai/) - Free courses with LangChain, CrewAI, AutoGen
 - [HuggingFace Agents Course](https://huggingface.co/learn/agents-course) - Open-source agent dev course
 - [LangGraph Academy](https://academy.langchain.com/) - Official LangGraph path


### PR DESCRIPTION
Refresh handbook metadata to current 77 stars

This keeps the existing DeepSeek Harness Handbook entry and refreshes only stale generated metadata.

- Handbook: https://github.com/sandbaseai/deepseek-harness-handbook
- Live repository metrics: 77 stars / 10 forks (2026-08-28)
- Latest release: https://github.com/sandbaseai/deepseek-harness-handbook/releases/tag/v0.5.273
- Validation: npm run check (157 canonical pages, 168 localized documents)

The focused diff keeps the catalog trustworthy without changing its structure or README.