### PR TITLE
Add Yad to Browser and Desktop Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@
 | [Fellou](https://fellou.ai) | Transparent. Visual workflow editing. Agentic memory. | Beta |
 | [Genspark](https://genspark.ai) | 169+ on-device models. No internet required. | Free / Paid |
 | [Grok Computer](https://x.ai) | ⭐ **Upcoming** xAI desktop agent. Mouse control, app automation. | TBA |
+| [Yad](https://github.com/holistis/al-yad) | OSS, local-first browser agent. Chrome/Brave/Edge extension + local companion turns plain language into clicks and typing using your own logins. Publishes red-team security results. | Free (OSS) |
 
 ### Developer Infrastructure
 


### PR DESCRIPTION
Adds Yad to the **Consumer Products** subsection of **Browser and Desktop Agents**, alongside similar plain-language browsing agents (Claude in Chrome, Dia Browser, Fellou).

**What it is:** Yad is a free, open-source (MIT), local-first AI browser agent. A Chrome/Brave/Edge extension plus a local companion turn plain-language instructions into real clicks and typing inside your own browser, using your own logins. No cloud copy of your accounts, and your API key stays encrypted on your device.

- GitHub: https://github.com/holistis/al-yad
- Website: https://yadagent.com
- Security: it publishes its own red-team security testing results publicly at https://yadagent.com/yad-security

Single-line addition, alphabetically last in the table (matches existing table format/columns). No other lines touched.