### PR TITLE
docs: add SandBase Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@
 | [Mastra](https://github.com/mastra-ai/mastra) | TS | TypeScript-first. Observational Memory. Apache 2.0. |
 | [Anthropic SDK](https://github.com/anthropics/anthropic-sdk-python) | Py/TS | Official Claude SDK. Tool use, computer control, streaming. |
 | [Google ADK](https://github.com/google/adk-python) | Py | ⭐ Google's Agent Development Kit. Native Gemini. Multi-agent orchestration. |
+| [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) | TS | Local-first runtime for persistent and auditable AI agent sessions, with sandboxed tools, MCP, memory, credentials, audit logs, and replay. |
 
 ### Multi-Agent Orchestration
 

--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@
 | [LibreChat](https://github.com/danny-avila/LibreChat) | Self-hosted multi-model chat. All major providers. |
 | [LobeChat](https://github.com/lobehub/lobe-chat) | OSS ChatGPT/Gemini UI. Plugin system. Multi-modal. |
 | [KinBot](https://github.com/MarlBurroW/kinbot) | Self-hosted AI agent platform. Persistent memory (hybrid search + LLM re-ranking), 23+ providers (including Ollama), plugin store, mini-apps SDK, cron scheduling, 6 messaging channels. SQLite, runs on a Pi. |
+| [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) | Local-first, self-hosted runtime for stateful AI agent sessions with persistent memory, MCP toolsets, approvals, audit/replay, and local, Docker, Kubernetes, or worker execution backends. |
 | [Anything LLM](https://github.com/Mintplex-Labs/anything-llm) | All-in-one AI app. RAG, agents. Desktop + Docker. |
 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | Data interaction with local LLM. 100% private. |
 


### PR DESCRIPTION
## Summary

Add SandBase Harness to the General Purpose Agent Frameworks list.

SandBase Harness is a local-first TypeScript runtime for persistent and auditable AI agent sessions, with sandboxed tools, MCP integration, memory, credentials, audit logs, and replay.

- Project: https://github.com/sandbaseai/sandbase-harness
- Documentation: https://github.com/sandbaseai/sandbase-harness/tree/main/docs
- Current release: v0.3.8

The entry follows the existing table format and uses a concise, factual description.
