### PR TITLE
Add Luphra to 3D and Design

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@
 
 | Tool | Description | Pricing |
 |------|-------------|---------|
+| [Luphra](https://luphra.com) | Text/sketch to editable 3D and manufactured physical products. | Free / Paid |
 | [Meshy](https://meshy.ai) | Text/image to 3D. Game assets, products. | Free / Paid |
 | [Tripo AI](https://tripo3d.ai) | Fast 3D from text/images. Multi-format export. | Free / Paid |
 | [Vizcom](https://vizcom.ai) | Real-time AI rendering for industrial designers. | From $20/mo |


### PR DESCRIPTION
## Summary
- Add [Luphra](https://luphra.com) to the **3D and Design** section (alphabetically before Meshy).
- One-line table entry matching existing format.

## Notes
- Luphra turns text/sketches into editable 3D and manufactured physical products (prompt-to-matter).
- **Affiliation disclosure:** I am the founder of Luphra.

## Checklist
- [x] Entry is in alphabetical order within its section
- [x] Link is valid and points to official source
- [x] Description is concise and factual
- [x] Pricing info is current
- [x] No promotional language