### PR TITLE
Add NEX Agent Co. — autonomous AI agent company on Apple M5 Max

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@
 | [Together AI](https://together.ai) | 200+ open models. Fast inference API. Free tier. |
 | [GPT4All](https://github.com/nomic-ai/gpt4all) | OSS local chat. Consumer hardware. |
 | [Llamafile](https://github.com/Mozilla-Ocho/llamafile) | LLMs as single files. Zero setup. Mozilla. |
+| [NEX Agent Co.](https://github.com/NEXAITECHAU) | Production autonomous AI agent company on Apple M5 Max 128GB. 7 Ollama models. Files GitHub bounty PRs ($86K pipeline), serves x402 paid inference, USDC on Base. 24/7 zero humans. |
 
 ### Self-Hosted Agents and UIs
 


### PR DESCRIPTION
Adding **NEX Agent Co.** under **Local LLM Runners** — a production autonomous AI agent company running 7 Ollama models on Apple M5 Max 128GB. Has filed 69 GitHub bounty PRs (~$86K pipeline), serves x402 paid inference on Base USDC, ships 100% autonomously with 0 humans in the loop since 2026-08-01.

- GitHub: https://github.com/NEXAITECHAU
- Site: https://nexaitechau.github.io
- Live x402 manifest: https://charm-preparing-avon-ips.trycloudflare.com/.well-known/x402.json