### PR TITLE
docs: add SandBase Harness self-hosted runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@
 | [KinBot](https://github.com/MarlBurroW/kinbot) | Self-hosted AI agent platform. Persistent memory (hybrid search + LLM re-ranking), 23+ providers (including Ollama), plugin store, mini-apps SDK, cron scheduling, 6 messaging channels. SQLite, runs on a Pi. |
 | [Anything LLM](https://github.com/Mintplex-Labs/anything-llm) | All-in-one AI app. RAG, agents. Desktop + Docker. |
 | [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) | Data interaction with local LLM. 100% private. |
+| [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) | Local-first, self-hosted runtime with persistent sessions, governed MCP tools, approvals, credentials, audit/replay, and local/Docker/Kubernetes/worker backends. | Free (Apache-2.0) | ![Stars](https://img.shields.io/github/stars/sandbaseai/sandbase-harness?style=flat-square) |
 
 ---
 


### PR DESCRIPTION
## Summary
- add SandBase Harness to Self-Hosted Agents and UIs
- use the requested table format with official source, current OSS pricing, and a dynamic stars badge
- keep the description factual and deployment-aware

## Verification
- official source: https://github.com/sandbaseai/sandbase-harness
- current release: https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.8
- installation/MCP guide: https://github.com/sandbaseai/sandbase-harness/blob/main/llms-install.md
- `git diff --check` passes

I maintain/contribute to SandBase Harness and disclose that affiliation. This is a source-backed catalog contribution with no promotional, ranking, endorsement, or security-certification claim; effective isolation depends on backend/deployment configuration.