### PR TITLE
Add Anchor to AI agent tools list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@
 | [Activepieces](https://github.com/activepieces/activepieces) | OSS Zapier alternative with AI. | Free (OSS) |
 | [Temporal](https://github.com/temporalio/temporal) | Durable execution for long-running agent workflows. | Free / Cloud |
 | [Mission Control](https://github.com/MeisnerDan/mission-control) | Cockpit for the agentic era — manage AI agent swarms with autonomous daemon, Field Ops for real-world execution, and approval workflows. | Free (OSS) |
+| [Anchor](https://github.com/n43ms/Anchor) | Crash-proof AI agent runtime. Sub-second OOM/crash recovery from exact failing step. 0 duplicate API calls/Double charges. | Free (OSS) |
 
 ### No-Code Agent Builders
 


### PR DESCRIPTION
Hi maintainers! Proposing Anchor for inclusion in the Task and Workflow Agents - Automation section.

  Anchor is a crash-proof execution runtime for AI agents. If worker process OOMs/cloud restarts/crashes mid-workflow Anchor reclaims run in sub-seconds & resumes execution from the exact failing step - guaranteeing 0 duplicate API calls/double-charges.

  GitHub: https://github.com/n43ms/Anchor
  Live Video Demos & Benchmarks: https://anchor-runtime.xyz/demo
  Documentation: https://anchor-runtime.xyz/docs