### PR TITLE
Add Agent Coordinator to Task and Workflow Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,12 +288,13 @@
 
 | Agent | Description | Pricing |
 |-------|-------------|---------|
-| [n8n](https://github.com/n8n-io/n8n) | OSS workflow automation with AI agent nodes. Visual + code. | Free / Cloud |
-| [Zapier AI](https://zapier.com/ai) | 7000+ apps. Natural language workflows. | From $19.99/mo |
-| [Make](https://make.com) | Visual workflow platform. AI capabilities. | Free / Paid |
 | [Activepieces](https://github.com/activepieces/activepieces) | OSS Zapier alternative with AI. | Free (OSS) |
-| [Temporal](https://github.com/temporalio/temporal) | Durable execution for long-running agent workflows. | Free / Cloud |
+| [Agent Coordinator](https://github.com/alanhoff/agent-coordinator) | Codex skill for breaking complex jobs into dependent work, preserving progress, and checking the result before completion. | Free (OSS) |
+| [Make](https://make.com) | Visual workflow platform. AI capabilities. | Free / Paid |
 | [Mission Control](https://github.com/MeisnerDan/mission-control) | Cockpit for the agentic era — manage AI agent swarms with autonomous daemon, Field Ops for real-world execution, and approval workflows. | Free (OSS) |
+| [n8n](https://github.com/n8n-io/n8n) | OSS workflow automation with AI agent nodes. Visual + code. | Free / Cloud |
+| [Temporal](https://github.com/temporalio/temporal) | Durable execution for long-running agent workflows. | Free / Cloud |
+| [Zapier AI](https://zapier.com/ai) | 7000+ apps. Natural language workflows. | From $19.99/mo |
 
 ### No-Code Agent Builders
 


### PR DESCRIPTION
## Summary

Adds Agent Coordinator to **Task and Workflow Agents > Automation**.

Agent Coordinator is an MIT-licensed Codex skill for work that has dependent steps or is difficult to reconstruct after an interruption. It records progress outside the target repository, supports optional specialists or inline execution, and checks the result before completion.

## Fit

This is a Codex workflow skill, not a hosted automation service or a general agent framework. The Automation subsection is the closest existing category for its dependent-work lifecycle.

## Validation

- The public repository is active and contains working code, installation instructions, usage documentation, and an MIT license.
- The project URL does not appear in the current README or open pull requests.
- The entry follows the live three-column Automation table and uses `Free (OSS)` for pricing.
- The existing Automation rows were not alphabetized. This change sorts that seven-row block while adding Agent Coordinator between Activepieces and Make.
- `git diff --check` passes.
- [CI passes at source commit `fb3d64688a9e1b7c02a114a14faac1219ec10f51`](https://github.com/alanhoff/agent-coordinator/actions/runs/33472714021).

## Disclosure

I maintain Agent Coordinator. AI helped draft this PR, and I checked the placement, description, links, pricing, and source claims against both repositories.

If another existing subsection fits better, I can move the row.
