### PR TITLE
Add AgentBridge to Terminal and CLI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Anthropic CLI agent. Best reasoning. 80.9% SWE-bench. Agent Teams feature. | $20/mo+ API |
 | [OpenAI Codex CLI](https://github.com/openai/codex) | OpenAI terminal agent. Agents SDK. Multi-agent. | ChatGPT sub |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | ⭐ **NEW (Apr 2026)** Google's official open-source terminal agent. ReAct loop. MCP support. 1M context. Apache 2.0. | Free w/ Google account |
+| [AgentBridge](https://github.com/raysonmeng/agent-bridge) | Local MIT CLI that keeps Claude Code and Codex as live peers in one session (mid-turn review, task split, quota-boundary handoff). | Free (OSS) |
 | [Aider](https://github.com/paul-gauthier/aider) | OSS pair programmer. Git-aware. Any LLM. | Free + API |
 | [Cline](https://github.com/cline/cline) | VS Code extension. Full terminal and browser access for Claude/GPT. | Free + API |
 | [RooCode](https://github.com/RooVetGit/Roo-Code) | Cline fork. Structured modes. Reduced hallucinations. | Free + API |


### PR DESCRIPTION
Adds AgentBridge under Terminal and CLI Agents (alphabetical before Aider). Local MIT CLI bridging Claude Code and Codex as live peers; complements the existing Claude Code and Codex CLI rows. Not a duplicate of either agent.

- [x] Alphabetical in section
- [x] Link valid
- [x] Description factual
- [x] Pricing Free (OSS)
- [x] No promotional language