### PR TITLE
Add BulkPublish agent platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@
 | [Zapier AI](https://zapier.com/ai) | 7000+ apps. Natural language workflows. | From $19.99/mo |
 | [Make](https://make.com) | Visual workflow platform. AI capabilities. | Free / Paid |
 | [Activepieces](https://github.com/activepieces/activepieces) | OSS Zapier alternative with AI. | Free (OSS) |
+| [BulkPublish](https://www.bulkpublish.com) | API and MCP server for AI agents to plan, review, schedule, publish, and analyze social media content. | Free trial / Paid |
 | [Temporal](https://github.com/temporalio/temporal) | Durable execution for long-running agent workflows. | Free / Cloud |
 | [Mission Control](https://github.com/MeisnerDan/mission-control) | Cockpit for the agentic era — manage AI agent swarms with autonomous daemon, Field Ops for real-world execution, and approval workflows. | Free (OSS) |
 


### PR DESCRIPTION
Adds BulkPublish to Task and Workflow Agents → Automation. BulkPublish gives AI agents an API and MCP server for social media planning, review, scheduling, publishing, and analytics.

Product: https://www.bulkpublish.com
Repository: https://github.com/azeemkafridi/bulkpublish-api
MCP docs: https://app.bulkpublish.com/docs

This is a self-submission.