### PR TITLE
Add AIWG

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@
 | [DSPy](https://github.com/stanfordnlp/dspy) | Py | Stanford. Programming not prompting. Auto-optimizes. |
 | [Mastra](https://github.com/mastra-ai/mastra) | TS | TypeScript-first. Observational Memory. Apache 2.0. |
 | [Anthropic SDK](https://github.com/anthropics/anthropic-sdk-python) | Py/TS | Official Claude SDK. Tool use, computer control, streaming. |
+| [AIWG](https://github.com/jmagly/aiwg) | TS | Open-source toolkit that deploys reusable agents, skills, and governed workflows across coding platforms. |
 | [Google ADK](https://github.com/google/adk-python) | Py | ⭐ Google's Agent Development Kit. Native Gemini. Multi-agent orchestration. |
 
 ### Multi-Agent Orchestration


### PR DESCRIPTION
Adds AIWG under General Purpose agent frameworks. The official GitHub repository is active, MIT-licensed, written primarily in TypeScript, and publicly installable through npm. The entry is concise and factual.