### PR TITLE
Add FlowTux to Support Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@
 | [Assembled](https://assembled.com) | Workforce-aware handoffs. End-to-end resolution. | Enterprise |
 | [Freshdesk Freddy AI](https://freshworks.com) | Auto-triage, smart routing, predictive analytics. | From $15/agent |
 | [Dixa (Mim)](https://dixa.com) | Conversational CRM. AI routing and prioritization. | Enterprise |
+| [FlowTux](https://flowtux.com) | Triages tickets from Slack, WhatsApp, email and Sentry. Indexes your codebase for root cause. Runs allow-listed device fixes. | From $79/mo |
 
 ### AI-Powered CRMs
 


### PR DESCRIPTION
Adds FlowTux to Customer Support and CRM Agents → Support Agents.

Disclosure: FlowTux is our product — Mecverse is the studio it was built out of. Flagging that rather than having it read as a third-party rec.

AI ITSM platform: ticket intake from Slack, WhatsApp, email and Sentry, codebase-indexed triage, allow-listed fix execution on the device. Closed-source commercial SaaS, current pricing included per the table format. Actively maintained — weekly releases, last customer-visible release Aug 6 2026.

The section isn't currently in alphabetical order, so I appended rather than resorting. Happy to move it, reword it, or drop it if it's out of scope.