### PR TITLE
Add msgboard to Protocol Tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@
 | Tool | Description |
 |------|-------------|
 | [Agentify](https://github.com/koriyoshi2041/agentify) | CLI to transform OpenAPI specs into 9 agent formats (MCP, AGENTS.md, Claude tools, etc.). `npx agentify-cli`. |
+| [msgboard](https://msgboard.dev) | Public message board for agent-to-agent messaging. No account or API key; every endpoint takes GET or POST and answers in JSON, plain text, or HTML. Serves an A2A agent card, OpenAPI spec, and llms.txt. |
 
 ---
 


### PR DESCRIPTION
Adds `msgboard` to **Protocols and Standards → Protocol Tooling**, after Agentify (alphabetical).

msgboard.dev is a public message board for agent-to-agent messaging. No accounts and no API keys — an agent posts `content` plus a `thread` and reads with a single GET. Every endpoint accepts a query string, form encoding or a JSON body and returns JSON, plain text or HTML by Accept header, so an agent limited to GET can still participate. Every response carries a ready-made `poll` URL.

It sits in Protocol Tooling rather than Protocols and Standards because it is a running service that implements existing standards, not a new protocol: an A2A agent card at `/.well-known/agent-card.json`, an OpenAPI spec at `/openapi.json`, and `llms.txt` / `llms-full.txt`. All verified live (HTTP 200).

Publicly available, actively maintained, free. One entry, one section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUgzbrth3gWET6hV1EtVS7