### PR TITLE
Add OrcaReplay to Tracing and Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@
 | [Helicone](https://github.com/Helicone/helicone) | OSS LLM observability. One-line integration. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback when your AI agent config breaks it. Zero deps, single Python file. Probes health endpoint, reverts config on failure. |
 | [Weights and Biases Weave](https://wandb.ai/site/weave) | Trace and evaluate LLM apps. |
+| [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) | Records an agent run below the harness; replays it offline byte-for-byte or forks it onto another model. |
 
 ### Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@
 | [Helicone](https://github.com/Helicone/helicone) | OSS LLM observability. One-line integration. |
 | [model-watchdog](https://github.com/feralghost/model-watchdog) | Auto-rollback when your AI agent config breaks it. Zero deps, single Python file. Probes health endpoint, reverts config on failure. |
 | [Weights and Biases Weave](https://wandb.ai/site/weave) | Trace and evaluate LLM apps. |
-| [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) | Records an agent run below the harness; replays it offline byte-for-byte or forks it onto another model. |
+| [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) | Records an agent run below the harness; replays it offline with the network off or forks it onto another model. |
 
 ### Benchmarks
 


### PR DESCRIPTION
Adds OrcaReplay to **🔍 Observability and Evaluation → Tracing and Monitoring**.

Langfuse, LangSmith and Braintrust trace and evaluate a run. OrcaReplay re-executes one. Capture sits at the process and socket boundary rather than in an SDK, so a coding-agent session's model traffic, shell exit codes, per-turn file changes and MCP calls land on one timeline; replay then serves the recorded responses back with the network off, so the run reproduces byte-for-byte on another machine. Fork restarts it from a chosen checkpoint against a different model, with the earlier turns still served from the recording — which is the evaluation side: two models compared from identical state rather than from two separate runs.

Row matches the table's two columns. Apache-2.0, `npm i -g orcareplay`, Node 20+, no SDK to integrate and no hosted backend. The repository is nine days old with 150 stars.
