### PR TITLE
Add Drevon

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@
 | [Instantly](https://instantly.ai) | AI cold email. Unlimited accounts. Smart rotation. | From $30/mo |
 | [Overloop CLI](https://github.com/sortlist/overloop-cli) | AI outbound CLI. Source 450M+ contacts, email + LinkedIn campaigns, conversations. Agent-native JSON output. | $69-99/mo |
 | [Lavender](https://lavender.ai) | AI email coach. Real-time scoring. | Free / $29/mo |
+| [Drevon](https://drevon.dev) | Console for GTM engineers. AI agents run evidence-backed prospecting, signal tracking, account research, and inbound qualification. Native browser uses your own LinkedIn, Sales Nav, and X logins; connects the rest of your GTM stack over MCP. For individuals, teams, or self-hosted enterprise. | Contact for pricing |
 
 ---
 


### PR DESCRIPTION
Adds **Drevon** (https://drevon.dev) to the **Sales and Outreach Agents** section, alongside Clay, Apollo.io, Instantly, and Lavender.

Drevon is a console for GTM engineers: AI agents run evidence-backed prospecting, signal tracking, account research, and inbound qualification. It ships with a native browser that uses the user's own LinkedIn, Sales Nav, and X logins, connects the rest of the GTM stack over MCP, and works for individuals, teams, or self-hosted enterprise deployments.

It fits this section because it competes directly in the same lead-gen / outbound-research space as the existing entries there.

Pricing is left as "Contact for pricing" — it's not yet finalized, so the entry avoids stating a number either way, per the repo's request for accurate, current info.

🤖 Generated with [Claude Code](https://claude.com/claude-code)