### PR TITLE
Add Inteldo to Data Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@
 | [AI for Database](https://aifordatabase.com) | Connect to any database and interact with it in plain English. No SQL needed — get instant insights, build self-refreshing dashboards, and trigger automated workflows based on database changes. | Free / Paid |
 | [Julius AI](https://julius.ai) | Upload CSV/Excel, ask in natural language. | Free / Paid |
 | [Hex AI](https://hex.tech) | Collaborative data platform. AI analysis. | Free / Paid |
+| [Inteldo](https://inteldo.com/) | Business research platform with specialist agents for analyzing connected business data and external sources. | Free / Paid |
 | [PandasAI](https://github.com/Sinaptik-AI/pandas-ai) | Chat with your data. NL to Pandas/SQL. | Free (OSS) |
 | [Signals CLI](https://github.com/sortlist/signals-cli) | Intent signal CLI. LinkedIn engagers, keyword posters, job changers, funding events. JSON output for agent pipelines. | Paid |
 | [TaskWeaver](https://github.com/microsoft/TaskWeaver) | Microsoft. Code-first data analytics agents. | Free (OSS) |


### PR DESCRIPTION
Adds Inteldo to the Data Analysis section.

Inteldo is a business research platform with specialist agents that analyze connected business data and external sources.
