### PR TITLE
Add Cue - sandboxed Windows coding agent (AppContainer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@
 |-------|-------------|---------|
 | [Devin](https://devin.ai) | Cognition. Fully autonomous. Sandboxed cloud env. Devin 2.0 with Interactive Planning. | $20/mo + ACU |
 | [Copilot Workspace](https://githubnext.com/projects/copilot-workspace) | GitHub issue-to-PR agent. | Copilot sub |
+| [Cue](https://github.com/zenovis2-create/cue) | Windows 11 Electron sandboxed coding agent. Codex CLI in capability-zero AppContainer; approved worktrees only. | Free (OSS / MIT) |
 | [SWE-Agent](https://github.com/princeton-nlp/SWE-agent) | Princeton. Resolves real GitHub issues autonomously. | Free (OSS) |
 | [OpenHands](https://github.com/All-Hands-AI/OpenHands) | OSS autonomous software engineer (ex-OpenDevin). | Free (OSS) |
 | [Grok Build (xAI)](https://x.ai) | 8 parallel agents for code gen. Multi-agent "Society of Mind" architecture. | xAI sub |


### PR DESCRIPTION
## Summary
Add [Cue](https://github.com/zenovis2-create/cue) under Coding Agents / Autonomous Software Engineers.

Windows 11 Electron sandboxed coding agent: Codex CLI in capability-zero AppContainer; approved worktrees only. Free (OSS / MIT).