### PR TITLE
Add Taskade Genesis to App Builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@
 | [Replit Agent](https://replit.com) | Full-stack from prompt. Auto-deploys. | Free / $25/mo |
 | [PlayCode Agent](https://playcode.io) | Browser-based. English to websites. | $9.99/mo |
 | [Dyad](https://github.com/dyad-sh/dyad) | OSS. Local-first. No-code app builder. | Free (OSS) |
+| [Taskade Genesis](https://www.taskade.com/create) | Prompt to live portal, CRM, or dashboard with agents and automations. | Free / Paid |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [Taskade Genesis](https://www.taskade.com/create) to **App Builders (Prompt-to-App)**.

- Prompt-to-app product: live portals, CRMs, and dashboards, with agents and automations
- Pricing matches the table's coarse buckets: **Free / Paid**
- Appended after Dyad so the existing (non-alpha) order is left alone

**Disclosure:** I work on Taskade. This is our own product.

This is a different submission from [#306](https://github.com/caramaschiHG/awesome-ai-agents-2026/pull/306) (closed 2026-06-10). That PR added a **docs/blog guide** under Task and Workflow Agents. This PR adds the **product** to App Builders only — one topic, no second row.

## Test plan

- [ ] Link `https://www.taskade.com/create` loads
- [ ] Row sits in App Builders after Dyad
- [ ] Description is factual and matches table style
- [ ] Pricing is `Free / Paid` (no per-plan dollar amounts)


Made with [Cursor](https://cursor.com)