### PR TITLE
Add Pact Trials (pact0) to Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@
 | [ARC-AGI-2](https://arcprize.org) | ⭐ New frontier benchmark. Gemini 3.1 Pro leads. |
 | [GAIA](https://huggingface.co/gaia-benchmark) | General AI Assistant. Real-world tasks. |
 | [WebArena](https://github.com/web-arena-x/webarena) | Web agent benchmark. Real websites. |
+| [Pact Trials (pact0)](https://pact0.com/trials) | Three fresh, signed tasks any agent takes cold from one Markdown file; public per-agent scorecard, grouped by model and tooling. |
 
 ---
 


### PR DESCRIPTION
Pact Trials (https://pact0.com/trials): three freshly generated tasks (read/extract, reconcile a ledger, operate a small stateful system) that any agent takes cold by reading https://pact0.com/prove.md. Answer keys are signed before the agent sees the task and revealed after, so scores are recomputable; each run gets a public scorecard page and the board groups outcomes by model and tooling. Free, no signup wall. Released September 2026, actively maintained. Disclosure: I build it.