### PR TITLE
Add Atlarix to IDE-Native Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 | [Sourcegraph Cody](https://sourcegraph.com/cody) | Excels at large codebases. Enterprise context engine. | Free / $9/mo |
 | [Google Antigravity](https://idx.google.com) | Free Claude Opus 4.6 access. Learning-focused. | Free |
 | [Kiro](https://kiro.dev) | Spec-driven development. Write specs → auto-generate tasks → implement. DevOps automation. | Free beta |
+| [Atlarix](https://atlarix.dev) | Desktop agent workstation for engineering teams. Repo search, sandboxed terminal, and file edits that wait for per-change approval. Bring your own API keys or run local models. | Free / $19/mo |
 
 ### Terminal and CLI Agents
 


### PR DESCRIPTION
## Summary

Adds [Atlarix](https://atlarix.dev) to **Coding Agents → IDE-Native Agents** as a single new table row. No other file or line is changed.

## Submission type

- [x] New tool/resource

## Project details

**Name:** Atlarix
**Official link:** https://atlarix.dev
**GitHub repository, if available:** none — the desktop app is proprietary; official builds are published as release artifacts at https://github.com/AmariahAK/atlarix-releases
**Suggested section:** Coding Agents → IDE-Native Agents
**Pricing:** Free / $19/mo
**License, if open source:** n/a (proprietary)

## Why it belongs

Atlarix is a coding agent: repository search, sandboxed terminal commands, and file edits that wait for per-change approval.

Placed under **IDE-Native Agents** because it is an agent you run while writing code in the editor you already use — VS Code, JetBrains, Vim — rather than a replacement for it. It is not an IDE plugin and not a CLI-only agent, so this is the closest existing subsection; I am happy to move the row to **Terminal and CLI Agents** instead if you would prefer it there.

## Proposed entry

```markdown
| [Atlarix](https://atlarix.dev) | Desktop agent workstation for engineering teams. Repo search, sandboxed terminal, and file edits that wait for per-change approval. Bring your own API keys or run local models. | Free / $19/mo |
```

## How to verify

- `git diff main` on this branch shows exactly one added line — `1 file changed, 1 insertion(+)`, zero deletions, no reformatting and no encoding change.
- In the rendered README the new row sits in the **IDE-Native Agents** table after `Kiro`, carrying the same three columns as every other row in that table; the table header and separator are untouched.
- `curl -sIL https://atlarix.dev` returns `308` then `200`, and the URL carries no UTM, referral or affiliate parameters.
- Nothing else moved: the existing entries, the Contents list and the header line are byte-identical to `main`.

## Checklist

- [x] I checked that this is not already listed — no existing entry; searching this repository's README, issues and pull requests for "atlarix" returns nothing.
- [x] I checked that there is no duplicate open PR for this project.
- [x] The link points to an official source (official site; the bare host 308-redirects permanently to the canonical `www` host).
- [x] The description is concise and factual.
- [x] The entry uses the existing table format (`| Agent | Description | Pricing |`).
- [x] The pricing label follows the surrounding section style — the app itself is free and Pro is $19/mo.
- [x] The URL has no UTM, referral, or affiliate parameters.
- [x] This PR changes only the relevant lines — one added line, no reformatting, no encoding change.
- [x] I have disclosed any affiliation below.

## Affiliation disclosure

Disclosure: I am affiliated with Atlarix (NorahLabs, atlarix.dev).