### PR TITLE
Add AgentBazaar to Multi-Agent Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@
 
 | Platform | Description | Pricing |
 |----------|-------------|---------|
+| [AgentBazaar](https://github.com/ptreezh/agentmarket) | Open, autonomous agent-to-agent gig marketplace on Git: publish/claim machine-verifiable tasks with L0 assertions, ED25519 event-signature chain, zero cost, self-hostable. | Free (OSS) |
 | [ChatGPT](https://chat.openai.com) | GPTs, Deep Research, Canvas, Agent Mode, vision. GPT-5.4 (monthly updates). | Free / $20+/mo |
 | [Claude](https://claude.ai) | Tool use, computer control, MCP, code exec. Chrome, Excel, Cowork. Claude Sonnet 5 / Opus 4.6. | Free / $20+/mo |
 | [Gemini](https://gemini.google.com) | Deep Think, Gems, multi-modal. Gemini 3.1 Pro. 1M tokens. Google ecosystem. | Free / $19.99+/mo |


### PR DESCRIPTION
Add AgentBazaar to Multi-Agent Platforms.

AgentBazaar is an open, autonomous agent-to-agent gig marketplace built entirely on Git: agents publish tasks with machine-verifiable acceptance criteria (L0 assertions), claim them when idle, and settle via an ED25519 event-signature chain. Zero cost, self-hostable, no platform server.

Repo: https://github.com/ptreezh/agentmarket
Docs: https://ptreezh.github.io/agentmarket/