### PR TITLE
Add Oathra to Open-Source Voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@
 | [Rasa](https://github.com/RasaHQ/rasa) | OSS conversational AI. Self-hosted. NLU training. |
 | [Pipecat](https://github.com/pipecat-ai/pipecat) | OSS voice and multimodal conversational AI. |
 | [Vocode](https://github.com/vocodedev/vocode-python) | OSS voice-based LLM agents. |
+| [Oathra](https://github.com/FORIFOR/oathra) | OSS runtime for agents that make phone calls (Twilio/SIP). Completion decided by code from the callee's words, not by the model. Playable simulator, no API key. |
 
 ---
 


### PR DESCRIPTION
Adds [Oathra](https://github.com/FORIFOR/oathra) to **Voice Agents → Open-Source Voice**.

- Apache-2.0, TypeScript. Current GitHub Release: [v0.1.15](https://github.com/FORIFOR/oathra/releases/tag/v0.1.15). The npm registry still serves 0.1.0.
- What it is: a runtime for AI agents that make phone calls (Twilio direct media, or any SIP trunk through a LiveKit gateway; GPT-Live / OpenAI Realtime / Deepgram+LLM+TTS engines).
- What makes it different from the other entries: the call result is not a model summary. Every field is anchored to something the *callee* said and completion is decided by deterministic rules; the repo ships a 10,000-run adversarial evaluation that must report 0 false completions.
- Optional follow-up intake is contract-declared and consent-based: one question per turn, scene-aware dependencies, and an immediate stop on decline, hold, ambiguity or time pressure. Explicit answers are saved with utterance provenance; no callee attributes are inferred.
- Usable without any API key: `npx --yes --package=https://github.com/FORIFOR/oathra/releases/download/v0.1.15/oathra-0.1.15.tgz oathra demo` runs two agents against each other in the browser (you can also answer the phone yourself).

Site: https://forifor.github.io/oathra/en/
48-second intake demo: https://forifor.github.io/oathra/en/#intake-video
