### PR TITLE
Add Agent Team to Multi-Agent Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@
 | [MagiC](https://github.com/kienbui1995/magic) | Go/Py | Kubernetes for AI agents. Manages any agent from any framework. Routing, cost control, DAG workflows, circuit breaker. |
 | [DeerFlow](https://github.com/bytedance/deer-flow) | Py | ByteDance. No.1 GitHub Trending Feb 2026. 25k+ stars. |
 | [AXME](https://github.com/AxmeAI/axme) | Py/TS/Go/Java/.NET | Durable coordination. Crash recovery, human approval gates, kill switch. Open protocol (AXP). |
+| [Agent Team](https://github.com/FORIFOR/Multibot) | Py/TS | One request → Master plans, Researcher/Builder/Reviewer work → artifacts plus the real bot-to-bot messages, a timeline and checks bound to each revision. Local-first; Claude Code CLI (no key), Claude API, OpenAI-compatible, Ollama. MIT. |
 
 ### Lightweight / Minimalist
 


### PR DESCRIPTION
Adds [Agent Team](https://github.com/FORIFOR/Multibot) (MIT) to Multi-Agent Orchestration.

One request → a Master plans → Researcher / Builder / Reviewer do the work → you get the artifacts plus the real bot-to-bot messages, a timeline, and checks bound to each artifact revision (append-only event log; runtime-enforced tool scope, budgets, approvals). Runs on the local Claude Code CLI without an API key, or on the Claude API, OpenAI-compatible endpoints and Ollama.

A real end-to-end run (claude-opus-5) with the unedited artifacts and event log is committed under docs/evidence/. Site with a 59s intro: https://forifor.github.io/Multibot/

Same row format as the existing entries.